### PR TITLE
Publish one package at a time when bootstrapping PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -24,6 +24,17 @@ on:
         default: testpypi
         type: choice
         options: [testpypi, pypi]
+      only:
+        description:
+          "Restrict the upload to one package. Bootstrap only: PyPI allows a
+          single *pending* (project-creating) publisher per workflow identity,
+          so brand-new projects are published one at a time — register the
+          pending publisher, run with only=<pkg>, repeat. Once the projects
+          exist they share the identity and publish together (all)."
+        required: true
+        default: all
+        type: choice
+        options: [all, sdk, cli, mcp]
 
 permissions:
   contents: read
@@ -84,6 +95,15 @@ jobs:
         with:
           name: distributions
           path: dist/
+
+      # Bootstrap mode (see the `only` input): drop every distribution except
+      # the requested package, so a first-time project can be created while
+      # its siblings' pending publishers do not exist yet.
+      - name: Restrict the upload to one package (bootstrap)
+        if: inputs.only != 'all'
+        run: |
+          find dist -type f ! -name "content_${{ inputs.only }}-*" -delete
+          echo "uploading only:" && ls -1 dist
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
PyPI allows a single *pending* (project-creating) trusted publisher per workflow identity — registering a second project against the same owner/repo/workflow/environment answers "already been registered for a different project name". Our three packages share one identity by design, so brand-new projects must be created one at a time; once they exist, regular publishers share the identity freely and the normal all-at-once publish applies.

The workflow gains an `only` input (all|sdk|cli|mcp, default all) that drops every other distribution before the upload. Bootstrap is: register the pending publisher for one project, run with only=<pkg>, repeat for the next — then never think about it again.