### PR TITLE
Spell the separator colon as " - ", give the first word its capital

### DIFF
--- a/apps/backend/content/naming/engine.py
+++ b/apps/backend/content/naming/engine.py
@@ -218,7 +218,15 @@ def curate_title(title: str, channel: str = "") -> str:
     cleaned = re.sub(r"\s*([|·–—-])(\s*\1)+\s*", r" \1 ", cleaned)
     cleaned = re.sub(r"^(?:[|·–—:-]\s*)+", "", cleaned)
     cleaned = re.sub(r"(?:\s*[|·–—:-])+$", "", cleaned)
-    return re.sub(r"\s{2,}", " ", cleaned).strip()
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()
+    # A name starts with a capital — but only when the first word is entirely
+    # lowercase ("twenty one pilots…" → "Twenty…"). A word that already mixes
+    # case is a brand's own spelling (iPhone, eBay) and is not corrected.
+    if cleaned:
+        first_word = cleaned.split(" ", 1)[0]
+        if first_word.islower():
+            cleaned = cleaned[0].upper() + cleaned[1:]
+    return cleaned
 
 
 def suggest_base_name(resource) -> str:

--- a/apps/backend/content/naming/sanitize.py
+++ b/apps/backend/content/naming/sanitize.py
@@ -19,6 +19,11 @@ import re
 _UNSAFE = re.compile(r"[^A-Za-z0-9._-]+")
 
 _SEPARATORS = re.compile(r"[/\\]+")
+# A colon *used as a separator* ("Artist: Title") keeps its meaning as " - ",
+# exactly like path separators above; only the separator usage (colon followed
+# by whitespace) qualifies, so "12:34" stays a time and degrades to a space
+# with the other forbidden characters below.
+_COLON_SEPARATOR = re.compile(r"\s*:\s+")
 _FORBIDDEN = re.compile(r'[\x00-\x1f\x7f|:"*?<>]+')
 _WHITESPACE = re.compile(r"\s+")
 _WINDOWS_RESERVED = frozenset(
@@ -39,6 +44,7 @@ def display_name(name: str, max_length: int = 120) -> str:
     caller decides the fallback (an empty *intent* is not the same as an
     empty *name*)."""
     cleaned = _SEPARATORS.sub(" - ", name)
+    cleaned = _COLON_SEPARATOR.sub(" - ", cleaned)
     cleaned = _FORBIDDEN.sub(" ", cleaned)
     cleaned = _WHITESPACE.sub(" ", cleaned).strip(" .")
     cleaned = cleaned[:max_length].rstrip(" .")

--- a/apps/backend/tests/test_naming.py
+++ b/apps/backend/tests/test_naming.py
@@ -31,7 +31,11 @@ from tests.conftest import make_request, minimal_payload
         ("My Conference", "My Conference"),
         ("Artist - Song / Official Video", "Artist - Song - Official Video"),
         ("a\\b", "a - b"),
-        ('What? A "quote": here*', "What A quote here"),
+        # A colon used as a separator keeps its meaning, like / and \ above…
+        ("twenty one pilots: Stressed Out", "twenty one pilots - Stressed Out"),
+        ('What? A "quote": here*', "What A quote - here"),
+        # …while a non-separator colon (no space after) degrades to a space.
+        ("Meeting at 12:34", "Meeting at 12 34"),
         ("  spaced   out  ", "spaced out"),
         ("Trailing dots...", "Trailing dots"),
         ("héhé — l'été à Zürich", "héhé — l'été à Zürich"),  # unicode survives
@@ -415,15 +419,36 @@ class TestCurateTitle:
 
         for title in (
             "Trapped by plates in The Sims",
-            "héhé — l'été à Zürich",
             "A.I. — the basics",
         ):
             assert curate_title(title) == title
+
+    def test_capitalizes_only_an_all_lowercase_first_word(self):
+        """ "twenty one pilots…" earns its capital; a word that already mixes
+        case is a brand's own spelling and is never corrected."""
+        from content.naming.engine import curate_title
+
+        assert curate_title("twenty one pilots") == "Twenty one pilots"
+        assert curate_title("héhé — l'été à Zürich") == "Héhé — l'été à Zürich"
+        assert curate_title("iPhone 15 review") == "iPhone 15 review"
+        assert curate_title("eBay finds of the year") == "eBay finds of the year"
 
     def test_decoration_only_title_curates_to_empty(self):
         from content.naming.engine import curate_title
 
         assert curate_title("🔥🔥🔥") == ""
+
+
+def test_suggest_base_name_shapes_a_music_video_title():
+    """The reference case, end to end: noise tag stripped, the separator colon
+    spelled as " - ", the first word given its capital."""
+    from content.domain.analysis import NormalizedResource
+    from content.naming.engine import suggest_base_name
+
+    resource = NormalizedResource(
+        title="twenty one pilots: Stressed Out [OFFICIAL VIDEO]"
+    )
+    assert suggest_base_name(resource) == "Twenty one pilots - Stressed Out"
 
 
 def test_suggest_base_name_offers_the_curated_title_with_raw_fallback():


### PR DESCRIPTION
"twenty one pilots: Stressed Out [OFFICIAL VIDEO]" proposed "twenty one pilots Stressed Out": the noise tag went, but the colon — filesystem-forbidden — degraded to a bare space, losing the separator it was, and the lowercase brand kept its lowercase. The proposal now reads "Twenty one pilots - Stressed Out".

Two rules, each deliberately narrow. The display profile already spells path separators as " - "; a colon *used as a separator* (followed by whitespace) now gets the same treatment, while "12:34" keeps degrading to a space like the other forbidden characters. And curation gives the first word a capital only when that word is entirely lowercase — a word that already mixes case is a brand's own spelling (iPhone, eBay) and is never corrected.

Both live on the shared path, so the prefilled proposal and the name the server picks on its own stay identical (ADR 0017/0018).