### PR TITLE
CLI: read --version from the wheel's metadata, not a literal

### DIFF
--- a/apps/cli/content_cli/__init__.py
+++ b/apps/cli/content_cli/__init__.py
@@ -1,3 +1,12 @@
 """content — command-line client for the Content engine."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+# The installed wheel's own version — never a literal. The 0.2.0 release
+# shipped `content --version` answering "0.1.0" because this file carried a
+# hardcoded string that no release tooling rewrote (it was the one version
+# declaration outside `make version`'s lockstep). Metadata cannot drift.
+try:
+    __version__ = version("content-cli")
+except PackageNotFoundError:  # an uninstalled source tree (no dist metadata)
+    __version__ = "0+source"


### PR DESCRIPTION
content-cli 0.2.0 answers "content 0.1.0": content_cli/__init__.py carried a hardcoded __version__ that no release tooling rewrote — the one version declaration outside make version's lockstep, and exactly the second literal the --version comment claimed not to have. The attribute now comes from importlib.metadata, like content-mcp already does, so there is nothing left to drift; an uninstalled source tree answers "0+source".

Cosmetic in 0.2.0 (wheels are immutable); correct from the next release on.