### PR TITLE
Author the release notes with the release

### DIFF
--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -67,6 +67,12 @@ jobs:
       - name: Write the checksum manifest
         run: cd dist && shasum -a 256 *.zip *.whl > SHA256SUMS.txt && cat SHA256SUMS.txt
 
+      # The draft's body comes from docs/releases/<tag>.md when the tree
+      # carries one — authored release notes, written with the release and
+      # reviewed like any other change — and only falls back to GitHub's
+      # generated notes (a bare commit/PR list) when no file exists. Writing
+      # the notes is part of preparing a release; the tag then publishes the
+      # words that were reviewed with the code they describe.
       - name: Create draft release for the tag, with the artifacts attached
         env:
           GH_TOKEN: ${{ github.token }}
@@ -78,10 +84,17 @@ jobs:
             gh release upload "$TAG" dist/*.zip dist/*.whl dist/SHA256SUMS.txt --clobber
             exit 0
           fi
+          notes="docs/releases/$TAG.md"
+          if [ -f "$notes" ]; then
+            notes_args="--notes-file $notes"
+          else
+            echo "No $notes in the tree — falling back to generated notes."
+            notes_args="--generate-notes"
+          fi
           gh release create "$TAG" \
             --draft \
             --verify-tag \
             --title "Content $TAG" \
-            --generate-notes \
+            $notes_args \
             dist/*.zip dist/*.whl dist/SHA256SUMS.txt
           echo "Draft created for $TAG — edit and publish it deliberately."

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,6 +59,8 @@ One engine, one official SDK, thin clients — each documents itself:
   yt-dlp base image is pinned, how updates are noticed, how a bump is validated
 - [operations/browser-extension-distribution.md](operations/browser-extension-distribution.md)
   — the release zip, and what publishing on the Chrome Web Store would involve
+- [releases/](releases/) — the authored release notes, one `vX.Y.Z.md` per
+  release; `release-draft.yml` uses the matching file as the draft's body.
 - [operations/release-readiness.md](operations/release-readiness.md) — what
   "releasable" means · [operations/github-settings.md](operations/github-settings.md)
   — the hosting settings the governance model assumes

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,74 @@
+Content 0.2.0 is the first release shaped by real daily use: playlists became
+first-class, SponsorBlock cutting stopped costing quality, and every client —
+web, CLI, MCP, browser extension — got closer to installable-in-one-command.
+
+## Highlights
+
+### Playlists are orchestrated, not approximated (ADR 0019)
+
+A collection no longer has its own artifact pipeline. Each member is analyzed,
+planned and executed by the exact pipeline a single video uses — so subtitles,
+multiple audio languages, SponsorBlock and naming all just work per member,
+and a member that cannot satisfy a request answers with its own structured
+reason while the others proceed. Files are numbered by the collection
+(`001 - Title.mkv`), provenance records each member's identity, and the UIs
+show progress as `3/6 · Title — downloading · 73%`.
+
+### SponsorBlock cuts preserve your streams (INV-019)
+
+> Preserve streams by default. Transcoding is explicit.
+
+Removing a sponsor segment used to be able to re-encode the whole file —
+turning a 17-second 4K AV1 download into 8½ minutes of CPU and an H.264 file
+46% larger. Content now removes segments itself with a keyframe-snapped,
+stream-copied cut: codecs untouched, I/O speed, and the end of the video
+provably clean (the historical "stuttering tail" came from a phantom
+keep-chunk in the upstream stream-copy path — measured, reproduced, and made
+structurally impossible). Frame-exact cutting remains available as an explicit
+`precise` opt-in that states its price.
+
+### Every client, one command away
+
+- **SDK, CLI and MCP server** are packaged for PyPI (hatchling, pinned
+  versions, licence files in the wheels, Trusted Publishing prepared). Until
+  the names are claimed, the wheels attached below install directly:
+  `uv tool install ./content_cli-0.2.0-py3-none-any.whl --find-links .`
+- **`content-mcp`** connects Claude, Cursor or any MCP client to your engine
+  with one config block — see
+  [apps/mcp/README.md](https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md).
+- **The Chromium extension** ships as
+  `content-browser-extension-chromium-v0.2.0.zip`: runtime files only,
+  verified by tests, ready for *Load unpacked*. (Chromium is now in the app's
+  name — a Safari sibling stays possible.)
+- **`SHA256SUMS.txt`** covers every asset: `shasum -a 256 -c SHA256SUMS.txt`.
+
+### Names worth keeping
+
+Artifact names are proposed by the engine and curated: `[4K]`-style noise
+tags, trailing hashtags, emoji flanks and known channel suffixes are removed —
+deterministically, never touching real content. The proposal a UI prefills is
+exactly the name the server would choose on its own, so leaving it untouched
+sends nothing and changes nothing.
+
+### Operating comfort
+
+- A turnkey `config/` space for cookies and runtime files, with the YouTube
+  credential declared by default and its freshness visible in the UIs.
+- The consoles read the engine live: per-step logs surfaced in HomeTube, a
+  modernized admin console, filtered event timelines, delivery that no longer
+  duplicates identical content.
+- `COMPOSE_PROFILES` selects which UIs run; the UI images lost ~98 MB each.
+- Release automation: version tags build the four GHCR images, draft the
+  release with all installable assets attached, and `make version` holds
+  fifteen version declarations in lockstep.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+The public contract is unchanged in shape; `sponsorblock.cut_mode` gains its
+stream-preserving default (`keyframes`) with `precise` as the explicit opt-in.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
A version tag drafted its release with GitHub's generated notes — a bare commit list, since there is little else to generate from. The words that present a release deserve the same treatment as the code: written while the release is prepared, reviewed in the same tree, and published by the same tag.

docs/releases/<tag>.md is that convention. release-draft.yml now uses the matching file as the draft's body and only falls back to generated notes when no file exists. v0.2.0's notes open the folder.