### PR TITLE
README: show the extension, not just its link

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ inventory.
       <sub><b>Content Console</b> — observe and pilot the engine</sub>
     </td>
   </tr>
+  <tr>
+    <td colspan="2" align="center">
+      <img src="https://github.com/LatentNoise/content/releases/download/v0.2.0/2026-08-10-browser_extension.jpg"
+           alt="HomeTube for Content — the Chromium extension popup on a video page" width="420"><br>
+      <sub><b>Browser extension</b> — the current tab to your library, in one click</sub>
+    </td>
+  </tr>
 </table>
 </div>
 


### PR DESCRIPTION
The visuals table showed Studio and the Console; the browser extension — the client a visitor can judge fastest — was only a bullet point. The v0.2.0 release carries its screenshot; it now sits centered under the two UIs, portrait width capped so the popup reads at a glance.