### PR TITLE
The packages are on PyPI — say so

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,16 @@ inventory.
 - **[Python SDK](packages/python-sdk/README.md)** — the typed sync and async
   client used by the Python applications.
 - **[CLI](apps/cli/README.md)** — ergonomic commands for analysis, generation,
-  job tracking, scripts, and raw requests. Installed from the wheels attached
-  to each release (`pipx install ./content_cli-*.whl --pip-args "--find-links ."`).
+  job tracking, scripts, and raw requests: `uv tool install content-cli`
+  (or `pipx install content-cli`).
 - **[Browser extension](apps/browser-extension-chromium/README.md)** — send the current
   tab to Content, in one click. Chromium (Chrome, Brave, Edge…); download the
   zip from a release, unzip, *Load unpacked*.
 - **[REST API](docs/contract.md)** — the versioned `/api/v1` contract, with
   OpenAPI and Swagger documentation.
 - **[MCP server](apps/mcp/README.md)** — intention-level tools and resources for
-  MCP-compatible agents.
+  MCP-compatible agents: `uv tool install content-mcp`, one config block in
+  Claude, Cursor, or any MCP client.
 
 <div align="center">
 <table>

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -8,7 +8,7 @@ there is no parallel contract.
 
 ## Install
 
-Once published, the CLI is an ordinary Python application — nothing to clone:
+The CLI is an ordinary Python application — nothing to clone:
 
 ```bash
 uv tool install content-cli     # isolated, on your PATH — recommended
@@ -18,23 +18,12 @@ content --help
 pipx install content-cli
 ```
 
-`content-cli` pulls `content-sdk` from PyPI as an ordinary dependency, pinned
-to the matching release.
-
-> **Not published yet.** Until the first publication the packages are attached
-> to each GitHub release as wheels; see *From a release* below. The commands
-> above are what will work afterwards.
-
-### From a release (today)
-
-Download `content_sdk-<version>-py3-none-any.whl` and
-`content_cli-<version>-py3-none-any.whl` from the
-[latest release](https://github.com/LatentNoise/content/releases/latest), then:
-
-```bash
-uv tool install ./content_cli-<version>-py3-none-any.whl \
-    --find-links .          # --find-links lets it resolve the SDK beside it
-```
+[`content-cli` on PyPI](https://pypi.org/project/content-cli/) pulls
+[`content-sdk`](https://pypi.org/project/content-sdk/) as an ordinary
+dependency, pinned to the matching release. The wheels are also attached to
+each [GitHub release](https://github.com/LatentNoise/content/releases/latest)
+for air-gapped installs (`uv tool install ./content_cli-<v>-py3-none-any.whl
+--find-links .`).
 
 ### From a clone
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -13,8 +13,7 @@ any MCP client → content-mcp (this) → content_sdk → your Content engine (/
 
 ## Install
 
-Once published, the server is an ordinary Python application — nothing to
-clone:
+The server is an ordinary Python application — nothing to clone:
 
 ```bash
 uv tool install content-mcp     # isolated, on your PATH — recommended
@@ -24,23 +23,12 @@ content-mcp --help
 pipx install content-mcp
 ```
 
-`content-mcp` pulls `content-sdk` from PyPI as an ordinary dependency, pinned
-to the matching release.
-
-> **Not published yet.** Until the first publication the packages are attached
-> to each GitHub release as wheels; see *From a release* below. The commands
-> above are what will work afterwards.
-
-### From a release (today)
-
-Download `content_sdk-<version>-py3-none-any.whl` and
-`content_mcp-<version>-py3-none-any.whl` from the
-[latest release](https://github.com/LatentNoise/content/releases/latest), then:
-
-```bash
-uv tool install ./content_mcp-<version>-py3-none-any.whl \
-    --find-links .          # --find-links lets it resolve the SDK beside it
-```
+[`content-mcp` on PyPI](https://pypi.org/project/content-mcp/) pulls
+[`content-sdk`](https://pypi.org/project/content-sdk/) as an ordinary
+dependency, pinned to the matching release. The wheels are also attached to
+each [GitHub release](https://github.com/LatentNoise/content/releases/latest)
+for air-gapped installs (`uv tool install ./content_mcp-<v>-py3-none-any.whl
+--find-links .`).
 
 ## Connect it to your engine
 

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -3,15 +3,12 @@
 ## Install
 
 ```bash
-pip install content-sdk
+pip install content-sdk        # https://pypi.org/project/content-sdk/
 ```
 
-> **Not published yet.** Until the first publication, the wheel is attached to
-> each [GitHub release](https://github.com/LatentNoise/content/releases/latest);
-> `pip install ./content_sdk-<version>-py3-none-any.whl`. From a clone:
-> `pip install ./packages/python-sdk`.
-
-Python 3.11+. Requires only `httpx` and `pydantic`.
+Python 3.11+. Requires only `httpx` and `pydantic`. The wheel is also attached
+to each [GitHub release](https://github.com/LatentNoise/content/releases/latest);
+from a clone: `pip install ./packages/python-sdk`.
 
 
 The official Python SDK for the [Content](../../README.md) engine — the **one**


### PR DESCRIPTION
content-sdk, content-cli and content-mcp 0.2.0 are published (Trusted Publishing, no stored tokens). Every "Not published yet" note retires: `uv tool install content-cli` / `content-mcp` and `pip install content-sdk` become the primary instructions, with the release-attached wheels demoted to the air-gapped fallback they now are. The root README install lines follow.