### PR TITLE
Adopt the mounted state so a fresh install starts (0.3.1)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.3.0"
+    org.opencontainers.image.version="0.3.1"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or
@@ -140,9 +140,16 @@ mkdir -p /data
 addgroup -g 1000 content
 adduser -D -s /bin/sh -u 1000 -G content content
 chown -R content:content /app /data
+# Privilege dropper for the entrypoint: the container starts as root only
+# long enough to make the mounted state writable (see docker-entrypoint.sh).
+apk add --no-cache su-exec
 SH
 
-USER content
+COPY --chmod=0755 apps/backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+# No `USER content` here: the entrypoint drops to that user itself, after
+# adopting bind mounts Docker created as root. Anything the image runs still
+# runs unprivileged — `docker compose exec content id` reports uid 1000.
 
 ENV CONTENT_DATA_DIR=/data \
     CONTENT_DB_PATH=/data/content.db \
@@ -152,5 +159,5 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=5 \
     CMD curl -fsS http://127.0.0.1:8000/api/v1/health || exit 1
 
-ENTRYPOINT ["/sbin/tini", "--"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["python3", "-m", "uvicorn", "content.api.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/apps/backend/docker-entrypoint.sh
+++ b/apps/backend/docker-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Make the mounted state writable, then drop to the unprivileged app user.
+#
+# Docker creates a missing bind-mount source directory as root:root. A first
+# `docker compose up -d` in an empty folder — the documented one-command
+# install — therefore handed the container a /data owned by root while the
+# process runs as uid 1000: the database was never created, the health check
+# never passed, and compose reported "container content is unhealthy". It only
+# worked on macOS, where Docker Desktop and Colima remap ownership for shared
+# folders, which is exactly why it survived development and broke on a Linux
+# homelab.
+#
+# Fixing it here rather than asking the operator to pre-create and chown
+# directories keeps the install one command on any host, whatever their uid.
+# The container still runs unprivileged: root exists for the length of this
+# script and nothing more.
+set -e
+
+APP_USER=content
+
+if [ "$(id -u)" = "0" ]; then
+    # Content's own state (database, jobs, artifacts, cache): always ours.
+    # Non-recursive on purpose — the app creates everything below /data as
+    # itself once the mount point is writable, and a recursive pass would
+    # scan an arbitrarily large artifact store on every start.
+    [ -d /data ] && chown "$APP_USER:$APP_USER" /data 2>/dev/null || true
+
+    # The delivery library belongs to the operator, not to Content: adopt it
+    # only when it is the empty directory Docker just created for us. An
+    # existing library keeps its ownership — silently chowning someone's media
+    # collection would be a worse bug than the one this fixes. When it is not
+    # writable, delivery fails per job with a clear error instead, and the
+    # operator points CONTENT_DELIVERY_DIR_HOST at a directory they own or
+    # sets `user:` in compose.
+    if [ -d /output ] && [ -z "$(ls -A /output 2>/dev/null)" ]; then
+        chown "$APP_USER:$APP_USER" /output 2>/dev/null || true
+    fi
+
+    exec su-exec "$APP_USER" "$@"
+fi
+
+# Already unprivileged (an explicit `user:` in compose, or a hardened
+# runtime): nothing to adjust, and nothing we could adjust anyway.
+exec "$@"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.3.0"
+version = "0.3.1"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.3.0"
+version = "0.3.1"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.3.0"]
+dependencies = ["content-sdk==0.3.1"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -29,7 +29,7 @@ INSTRUCTIONS = (
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.3.0", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.3.1", instructions=INSTRUCTIONS)
 
     # --- tools (intention-level) ---------------------------------------------
     @server.tool()

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.3.0", "mcp>=1.2"]
+dependencies = ["content-sdk==0.3.1", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.3.0"
+version = "0.3.1"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -24,7 +24,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -11,6 +11,24 @@ build-free twin for installs from the published images, no source tree
 needed (the README's quick start). `tests/test_deploy_compose.py` keeps
 them in lockstep.
 
+## Container user and mounted state
+
+The engine image starts as root, adopts the directories mounted into it, then
+drops to the unprivileged `content` user (uid 1000) before running anything —
+`docker compose exec content ps` shows the engine as `content`.
+
+That startup step exists because Docker creates a missing bind-mount source
+directory as `root:root`, which made a first `docker compose up -d` in an
+empty folder fail with *"container content is unhealthy"* on Linux (v0.3.1).
+`/data` is always adopted. The delivery library is adopted **only when it is
+empty**: an existing library keeps its ownership, since rewriting the
+ownership of an operator's media collection would be worse than the failure it
+would avoid.
+
+If delivery fails on a library owned by another user, point
+`CONTENT_DELIVERY_DIR_HOST` at a directory you own, or set `user:` on the
+`content` service to match the library's uid/gid.
+
 ## Topology
 
 | Service | Role | Host port | Runs | Base |

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,32 @@
+A fix release for the one command that matters most: installing Content.
+
+## The fresh install works on Linux
+
+`docker compose up -d` in an empty folder failed on a Linux host with
+`dependency failed to start: container content is unhealthy` — the very
+command 0.3.0's notes advertise.
+
+Docker creates a missing bind-mount source directory as `root:root`, while the
+engine runs unprivileged as uid 1000. The container was handed a `/data` it
+could not write to: no database, no passing health check. It went unnoticed
+because macOS (Docker Desktop, Colima) remaps ownership for shared folders, so
+the same command had always worked on the development machine.
+
+The image now starts as root only long enough to adopt its mounted state, then
+drops to the app user before anything else runs — `ps` inside the container
+still shows the engine as `content`, never root. `/data` is always adopted;
+the delivery library is adopted **only when it is empty**, because silently
+rewriting the ownership of someone's media collection would be a worse bug
+than the one this fixes.
+
+No action is needed beyond upgrading, and the install is unchanged:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+If your delivery library already exists and belongs to another user, point
+`CONTENT_DELIVERY_DIR_HOST` at a directory you own, or set `user:` on the
+`content` service to match its ownership.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.3.0...v0.3.1

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -41,7 +41,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 __all__ = [
     "APIError",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.3.0"
+version = "0.3.1"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/tests/test_container_permissions.py
+++ b/tests/test_container_permissions.py
@@ -1,0 +1,64 @@
+"""The container must survive a fresh bind mount (the one-command install).
+
+Docker creates a missing bind-mount source directory as root:root, so the
+first `docker compose up -d` in an empty folder hands the engine a /data it
+cannot write to when the process runs unprivileged — the database is never
+created, the health check never passes, and compose reports "container content
+is unhealthy". It only worked on macOS, where Docker Desktop and Colima remap
+ownership for shared folders, which is why it survived development and broke
+on a Linux host.
+
+The image therefore starts as root, adopts the mounts in its entrypoint, and
+drops to the app user. These guards keep that contract intact: they are static
+(the real behaviour is verified by building and running the image, which is
+too slow for the hermetic suite) but they catch the three ways it silently
+regresses — a reinstated `USER`, an entrypoint that bypasses the script, and a
+script that forgets to drop privileges.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+DOCKERFILE = (REPO / "apps" / "backend" / "Dockerfile").read_text()
+ENTRYPOINT = (REPO / "apps" / "backend" / "docker-entrypoint.sh").read_text()
+
+
+def test_the_entrypoint_runs_the_ownership_script():
+    """tini stays PID 1 (it reaps yt-dlp/ffmpeg children); the script runs
+    under it."""
+    line = next(
+        line for line in DOCKERFILE.splitlines() if line.startswith("ENTRYPOINT")
+    )
+    assert "/sbin/tini" in line, "tini must remain the init process"
+    assert "docker-entrypoint.sh" in line, (
+        "the entrypoint must run the ownership script, or a fresh install "
+        "starts with an unwritable /data again"
+    )
+
+
+def test_the_image_does_not_pin_itself_to_the_unprivileged_user():
+    """A `USER content` line would make the entrypoint unable to chown the
+    mount — the exact failure this design removes."""
+    users = [
+        line
+        for line in DOCKERFILE.splitlines()
+        if line.strip().startswith("USER ") and "root" not in line
+    ]
+    assert not users, f"remove {users}: the entrypoint drops privileges itself"
+
+
+def test_the_script_drops_privileges():
+    assert "su-exec" in ENTRYPOINT, "the app must not keep running as root"
+    assert "apk add --no-cache su-exec" in DOCKERFILE, "su-exec must be installed"
+    assert 'exec su-exec "$APP_USER" "$@"' in ENTRYPOINT
+
+
+def test_the_script_adopts_data_but_never_an_existing_library():
+    """/data is Content's own state. /output is the operator's media library:
+    adopting a non-empty one would rewrite the ownership of their collection."""
+    assert 'chown "$APP_USER:$APP_USER" /data' in ENTRYPOINT
+    assert '-z "$(ls -A /output 2>/dev/null)"' in ENTRYPOINT, (
+        "the delivery library must only be adopted when empty"
+    )


### PR DESCRIPTION
`docker compose up -d` in an empty folder — the install the README and the 0.3.0 notes advertise — failed on Linux with "container content is unhealthy". Docker creates a missing bind-mount source as root:root while the engine runs as uid 1000, so /data was unwritable: no database, no passing health check. macOS hides this by remapping ownership for shared folders, which is why it worked on the development machine and broke on a homelab.

The image now starts as root, chowns what it owns, and drops to the app user through su-exec before running anything — the engine process is still unprivileged. /data is always adopted; the delivery library only when empty, because silently rewriting the ownership of an operator's media collection would be a worse bug than this one.

Verified by building the image and starting it against a root-owned mount: /data becomes content:content, the health endpoint answers ok, and ps shows uvicorn running as content. tests/test_container_permissions.py guards the three silent regressions — a reinstated USER, an entrypoint bypassing the script, and a script that forgets to drop privileges.