### PR TITLE
Refuse commits that carry the wrong identity

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Keep tool attribution out of the history.
+#
+# Content's commit messages describe the change and its reasoning; they never
+# advertise what typed them. The patterns below are attribution *trailers* and
+# badges, never prose — a commit that legitimately discusses the Anthropic
+# summarizer or a Claude model id passes untouched, which is why this matches
+# `Co-Authored-By:` and not a bare vendor name.
+message_file="$1"
+
+if grep -qiE '^(co-authored-by:.*(claude|copilot|cursor|bot@)|generated with)' "$message_file" \
+   || grep -q '🤖' "$message_file"; then
+    echo "commit refused: the message carries tool attribution"
+    echo
+    grep -inE '^(co-authored-by:|generated with)|🤖' "$message_file" | sed 's/^/  /'
+    echo
+    echo "Remove those lines (AGENTS.md: nothing in this repository advertises"
+    echo "what wrote it)."
+    exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Refuse a commit authored by anything but Content's public identity.
+#
+# This machine carries two identities: `git config --global user.email` is a
+# personal gmail address, and this repository overrides it locally. The
+# override is one command away from being absent — a fresh clone, a new
+# worktree, a reset — and a wrong author in a public commit cannot be
+# corrected without rewriting published history.
+#
+# Content is offered under the AGPL with the option of separate commercial
+# terms, which only holds because copyright sits with one identifiable person
+# (COMMERCIAL.md). One identity in the record is part of that argument, not
+# cosmetics.
+expected="yann@orieult.com"
+actual=$(git config user.email)
+
+if [ "$actual" != "$expected" ]; then
+    echo "commit refused: author is '${actual:-unset}', expected '$expected'"
+    echo
+    echo "  git config user.email $expected"
+    echo
+    echo "(this repository's identity is documented in AGENTS.md)"
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@
 # Licence and governance: extensionless by convention, so allowlisted by name.
 !LICENSE
 !NOTICE
+# Git hooks: extensionless by Git's own contract (the file must be named
+# exactly `pre-commit`), so they need naming here or the allowlist would hide
+# the very guard that protects the commit identity. Armed with `make hooks`.
+!.githooks/pre-commit
+!.githooks/commit-msg
 !.github/CODEOWNERS
 !.github/ISSUE_TEMPLATE/*.yml
 !.github/workflows/*.yml

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ VERSION_MODULES    := apps/backend/content/__init__.py \
                       apps/web-admin/app.py
 
 .DEFAULT_GOAL := validate
-.PHONY: help install format lint test test-all ui-venv test-ui test-ui-live \
+.PHONY: help install hooks format lint test test-all ui-venv test-ui test-ui-live \
         validate validate-all validate-release clean run \
         version version-update version-tag wheels deploy-compose extension-zip docker-up docker-update docker-down \
         docker-logs
@@ -35,10 +35,18 @@ help:  ## List the available targets
 	@grep -hE '^[a-zA-Z][a-zA-Z0-9_-]*:.*##' $(MAKEFILE_LIST) \
 	  | awk -F ':.*## ' '{printf "  \033[1m%-18s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Create the venv and install the engine + SDK + CLI + MCP + shared client
+install: hooks  ## Create the venv and install the engine + SDK + CLI + MCP + shared client
 	cd apps/backend && uv venv .venv && uv pip install -e ".[test,dev,pdf]" --python .venv/bin/python
 	uv pip install -e packages/python-sdk --python apps/backend/.venv/bin/python
 	uv pip install -e apps/cli -e apps/mcp --python apps/backend/.venv/bin/python
+
+# Git hooks live in .githooks/ (tracked, so a fix reaches every checkout)
+# rather than .git/hooks/ (local, invisible, copied once and then stale).
+# Pointing core.hooksPath at them is the whole installation, and `make install`
+# does it so a fresh clone is guarded before its first commit.
+hooks:  ## Arm the tracked git hooks (identity + attribution guards)
+	@git config core.hooksPath .githooks
+	@echo "git hooks armed from .githooks/ (identity: $$(git config user.email))"
 
 format:  ## Rewrite code to the canonical style (ruff format)
 	$(VENV)/ruff format $(SRC)

--- a/tests/test_git_hooks.py
+++ b/tests/test_git_hooks.py
@@ -1,0 +1,74 @@
+"""The commit guards must stay committable, executable and armed.
+
+The hooks refuse a commit authored by the wrong identity, and a message
+carrying tool attribution. Both are protections whose failure is *silent* —
+nothing tells you a hook was never installed, and a wrong author in a public
+commit cannot be corrected without rewriting published history. So the guard
+guards the guard:
+
+* the allowlist `.gitignore` hides extensionless files by default, and a hook
+  MUST be named exactly `pre-commit` — the same rule that once hid the Typst
+  template (D-41) and the renamed extension's sources;
+* a hook without its execute bit is ignored by Git without a word;
+* `core.hooksPath` is what makes tracked hooks run at all.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+HOOKS = REPO / ".githooks"
+NAMES = ("pre-commit", "commit-msg")
+
+
+def test_the_hooks_exist_and_are_executable():
+    for name in NAMES:
+        hook = HOOKS / name
+        assert hook.is_file(), f"{name} is missing"
+        assert os.access(hook, os.X_OK), (
+            f"{name} has no execute bit — Git skips it silently"
+        )
+
+
+def test_the_allowlist_does_not_hide_them():
+    """Extensionless by Git's own contract, so the allowlist must name them."""
+    result = subprocess.run(
+        ["git", "check-ignore", "--stdin"],
+        cwd=REPO,
+        input="\n".join(f".githooks/{name}" for name in NAMES),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    hidden = [line for line in result.stdout.split("\n") if line.strip()]
+    assert not hidden, (
+        f"the allowlist hides {hidden} — they could never be committed, so "
+        "every clone would be unguarded"
+    )
+
+
+def test_the_identity_guard_names_the_public_address():
+    hook = (HOOKS / "pre-commit").read_text()
+    assert 'expected="yann@orieult.com"' in hook
+    assert "git config user.email" in hook, "the message must say how to fix it"
+
+
+def test_the_attribution_guard_matches_trailers_not_prose():
+    """A commit that legitimately discusses the Anthropic summarizer or a
+    model id must pass; only attribution trailers and badges are refused."""
+    hook = (HOOKS / "commit-msg").read_text()
+    assert "co-authored-by:" in hook.lower()
+    assert "generated with" in hook.lower()
+    # Anchored to the start of a line: prose mentioning a vendor stays legal.
+    assert "'^(co-authored-by:" in hook
+
+
+def test_make_install_arms_them():
+    """A fresh clone must be guarded before its first commit, without anyone
+    remembering to run an extra step."""
+    makefile = (REPO / "Makefile").read_text()
+    assert "install: hooks" in makefile, "make install must depend on hooks"
+    assert "git config core.hooksPath .githooks" in makefile


### PR DESCRIPTION
Content is offered under the AGPL with the option of separate commercial terms, which holds only because copyright sits with one identifiable person. This machine carries two identities: the global git config is a personal gmail address and only this repository overrides it, so a fresh clone, a new worktree or a reset would silently author public commits as someone else — and a wrong author cannot be corrected without rewriting published history.

.githooks/ makes that mechanical rather than remembered: pre-commit refuses an author other than yann@orieult.com, commit-msg refuses tool attribution. They are tracked, not left in .git/hooks/, so a fix reaches every checkout instead of one machine; `make install` arms them through core.hooksPath, so a clone is guarded before its first commit.

Two traps handled on the way. The allowlist .gitignore hid both files — a hook must be named exactly `pre-commit`, and extensionless files are ignored by default, the same rule that once hid the Typst template. And the attribution check is anchored to trailers, so a commit that legitimately discusses the Anthropic summarizer passes: verified, along with both refusals.