### PR TITLE
Give audio acquisition the resilience video always had

### DIFF
--- a/apps/backend/content/providers/ytdlp.py
+++ b/apps/backend/content/providers/ytdlp.py
@@ -93,6 +93,21 @@ _CODEC_PRIORITY = ("av1", "vp9", "h264")
 # Rotated only for YouTube URLs (the arg is ignored by other extractors).
 _PLAYER_CLIENTS = ("", "ios", "web")
 
+# Acquisition attempts for an audio-only download, in order.
+#
+# The default client appears twice on purpose, and the repeat is the point.
+# A media URL is signed and short-lived, and every yt-dlp invocation
+# re-extracts it — so running the same command again is exactly what recovers
+# a transient `HTTP Error 403: Forbidden`. Observed on a real job whose video
+# output succeeded while the audio output, asking for the *same* stream
+# seconds later, was refused; the identical command then succeeded on replay.
+#
+# The alternative clients come last because they usually cannot serve
+# audio-only formats at all — `ios` and `web` answer "only images are
+# available" without a PO token — so trying them before a plain retry would
+# turn a recoverable blip into a different, more confusing failure.
+_AUDIO_ATTEMPTS = ("", "", "ios", "web")
+
 
 def _client_args(client: str) -> list[str]:
     return ["--extractor-args", f"youtube:player_client={client}"] if client else []
@@ -912,42 +927,76 @@ class YtDlpProvider:
         self, step: PlanStep, ctx: ExecutionContext
     ) -> list[ProducedFile]:
         base = f"audio-{step.id}"
+        uri = step.params["uri"]
         cookie_file = prepare_cookies(
             step.params.get("credential_id"), ctx.settings, ctx.workdir
         )
-        args = [
-            self.binary,
-            "--newline",
-            "--no-playlist",
-            "-o",
-            f"{base}.%(ext)s",
-            "--paths",
-            f"home:{ctx.workdir}",
-            "-f",
-            audio_language_selector(step.params.get("audio_languages")),
-            "--force-overwrites",
-            "--retries",
-            "10",
-            *audio_format_args(step.params),
-            *cookies_args(cookie_file),
-            *sponsorblock_args(step.params),
-            *extra_args(ctx.settings, step.params),
-            step.params["uri"],
-        ]
-        self._run(args, ctx)
-        produced = _find_by_ext(ctx.workdir, base, AUDIO_EXTS)
-        if not produced:
-            raise StepExecutionError(
-                "no_output", "Audio acquisition succeeded but produced no audio file."
-            )
-        attributes = self._apply_fast_sponsorblock_cut(step, ctx, produced) or {}
-        return [
-            ProducedFile(
-                path=produced,
-                media_type=media_type_for(produced),
-                attributes=attributes,
-            )
-        ]
+
+        def args_for(client: str) -> list[str]:
+            return [
+                self.binary,
+                "--newline",
+                "--no-playlist",
+                "-o",
+                f"{base}.%(ext)s",
+                "--paths",
+                f"home:{ctx.workdir}",
+                "-f",
+                audio_language_selector(step.params.get("audio_languages")),
+                "--force-overwrites",
+                "--retries",
+                "10",
+                *audio_format_args(step.params),
+                *_client_args(client),
+                *cookies_args(cookie_file),
+                *sponsorblock_args(step.params),
+                *extra_args(ctx.settings, step.params),
+                uri,
+            ]
+
+        # Video acquisition has had a fallback ladder since the beginning;
+        # audio had a single shot, so one refused request ended the output
+        # while the video beside it — which had recovered from the very same
+        # kind of refusal — succeeded. Same resilience, now, for both.
+        attempts = _AUDIO_ATTEMPTS if _is_youtube(uri) else ("",)
+        last_error: StepExecutionError | None = None
+        for attempt, client in enumerate(attempts):
+            try:
+                self._run(args_for(client), ctx)
+            except StepExecutionError as exc:
+                # A cancelled or timed-out step is a decision, not a hiccup.
+                if exc.code in ("cancelled", "timeout"):
+                    raise
+                last_error = exc
+                continue
+            produced = _find_by_ext(ctx.workdir, base, AUDIO_EXTS)
+            if produced is None:
+                last_error = StepExecutionError(
+                    "no_output", "yt-dlp reported success but no audio file."
+                )
+                continue
+            attributes: dict = {"player_client": client or "default"}
+            if attempt > 0:
+                # Provenance says the first answer was refused: an operator
+                # comparing two runs should not have to guess why one took
+                # longer or came from another client.
+                attributes["attempts"] = attempt + 1
+                if client:
+                    attributes["selection"] = "fallback"
+            cut = self._apply_fast_sponsorblock_cut(step, ctx, produced)
+            if cut:
+                attributes.update(cut)
+            return [
+                ProducedFile(
+                    path=produced,
+                    media_type=media_type_for(produced),
+                    attributes=attributes,
+                )
+            ]
+
+        raise last_error or StepExecutionError(
+            "no_output", "Audio acquisition failed for every attempt."
+        )
 
     def _acquire_thumbnail(
         self, step: PlanStep, ctx: ExecutionContext

--- a/apps/backend/tests/test_audio_resilience.py
+++ b/apps/backend/tests/test_audio_resilience.py
@@ -1,0 +1,165 @@
+"""Audio acquisition survives a refused first attempt.
+
+A real job asked one YouTube URL for both video and audio. The video output
+succeeded; the audio output — asking for the *same* opus stream seconds later
+— was refused with `HTTP Error 403: Forbidden`, and the job failed. Replaying
+the identical command minutes later succeeded, so the refusal was transient:
+a media URL is signed and short-lived, and every yt-dlp invocation
+re-extracts it.
+
+The video path had carried a fallback ladder since the beginning (codec
+profiles × player clients) and recovered without anyone noticing. The audio
+path had a single shot. These tests hold both to the same standard, with the
+`ios`/`web` clients deliberately *last*: they usually cannot serve audio-only
+formats at all ("only images are available" without a PO token), so reaching
+for them before a plain retry would replace a recoverable blip with a
+different failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from content.domain.plan import PlanStep
+from content.providers.base import ExecutionContext, StepExecutionError
+from content.providers.ytdlp import _AUDIO_ATTEMPTS, YtDlpProvider
+
+YOUTUBE = "https://www.youtube.com/watch?v=pXRviuL6vMY"
+
+
+def _step(uri: str = YOUTUBE) -> PlanStep:
+    return PlanStep(
+        id="audio_main",
+        operation="media.acquire_audio",
+        provider="ytdlp",
+        params={"uri": uri, "audio_languages": []},
+    )
+
+
+def _ctx(tmp_path: Path, settings) -> ExecutionContext:
+    return ExecutionContext(
+        settings=settings,
+        workdir=tmp_path,
+        stdout_log=tmp_path / "out.log",
+        stderr_log=tmp_path / "err.log",
+        timeout_seconds=60,
+    )
+
+
+class _Recorder:
+    """Stands in for yt-dlp: fails the first `failures` attempts, then writes
+    the file the provider looks for."""
+
+    def __init__(
+        self, tmp_path: Path, failures: int, error_code: str = "provider_error"
+    ):
+        self.tmp_path = tmp_path
+        self.failures = failures
+        self.error_code = error_code
+        self.clients: list[str] = []
+
+    def __call__(self, args, ctx):
+        # The client is what `--extractor-args youtube:player_client=X` carries.
+        client = ""
+        for index, value in enumerate(args):
+            if value == "--extractor-args" and index + 1 < len(args):
+                client = args[index + 1].split("=", 1)[-1]
+        self.clients.append(client)
+        if len(self.clients) <= self.failures:
+            raise StepExecutionError(self.error_code, "yt-dlp exited with code 1.")
+        (self.tmp_path / "audio-audio_main.m4a").write_bytes(b"audio")
+
+
+def test_the_default_client_is_retried_before_any_alternative():
+    """The observed failure: a transient refusal of the default client. The
+    recovery is the same command again, not a different client."""
+    assert _AUDIO_ATTEMPTS[:2] == ("", ""), "the default must be tried twice first"
+    assert _AUDIO_ATTEMPTS[2:] == ("ios", "web"), "alternatives come after"
+
+
+def test_a_transient_refusal_is_retried_and_the_output_survives(
+    tmp_path, settings, monkeypatch
+):
+    provider = YtDlpProvider()
+    recorder = _Recorder(tmp_path, failures=1)
+    monkeypatch.setattr(
+        YtDlpProvider, "_run", lambda self, args, ctx: recorder(args, ctx)
+    )
+    monkeypatch.setattr(
+        YtDlpProvider, "_apply_fast_sponsorblock_cut", lambda self, s, c, p: None
+    )
+
+    produced = provider._acquire_audio(_step(), _ctx(tmp_path, settings))
+
+    assert len(produced) == 1
+    assert recorder.clients == ["", ""], "retried the default, did not jump to ios"
+    assert produced[0].attributes["attempts"] == 2, "provenance records the retry"
+
+
+def test_alternatives_are_reached_when_the_default_keeps_refusing(
+    tmp_path, settings, monkeypatch
+):
+    provider = YtDlpProvider()
+    recorder = _Recorder(tmp_path, failures=2)
+    monkeypatch.setattr(
+        YtDlpProvider, "_run", lambda self, args, ctx: recorder(args, ctx)
+    )
+    monkeypatch.setattr(
+        YtDlpProvider, "_apply_fast_sponsorblock_cut", lambda self, s, c, p: None
+    )
+
+    produced = provider._acquire_audio(_step(), _ctx(tmp_path, settings))
+
+    assert recorder.clients == ["", "", "ios"]
+    assert produced[0].attributes["selection"] == "fallback"
+    assert produced[0].attributes["player_client"] == "ios"
+
+
+def test_every_attempt_failing_reports_the_provider_error(
+    tmp_path, settings, monkeypatch
+):
+    provider = YtDlpProvider()
+    recorder = _Recorder(tmp_path, failures=99)
+    monkeypatch.setattr(
+        YtDlpProvider, "_run", lambda self, args, ctx: recorder(args, ctx)
+    )
+
+    with pytest.raises(StepExecutionError) as excinfo:
+        provider._acquire_audio(_step(), _ctx(tmp_path, settings))
+
+    assert excinfo.value.code == "provider_error", "the real reason, not 'no_output'"
+    assert len(recorder.clients) == len(_AUDIO_ATTEMPTS)
+
+
+def test_cancellation_is_a_decision_not_a_hiccup(tmp_path, settings, monkeypatch):
+    """A cancelled or timed-out step must not be retried into oblivion."""
+    provider = YtDlpProvider()
+    recorder = _Recorder(tmp_path, failures=99, error_code="cancelled")
+    monkeypatch.setattr(
+        YtDlpProvider, "_run", lambda self, args, ctx: recorder(args, ctx)
+    )
+
+    with pytest.raises(StepExecutionError) as excinfo:
+        provider._acquire_audio(_step(), _ctx(tmp_path, settings))
+
+    assert excinfo.value.code == "cancelled"
+    assert recorder.clients == [""], "stopped at the first attempt"
+
+
+def test_a_non_youtube_source_gets_one_attempt(tmp_path, settings, monkeypatch):
+    """The client rotation is a YouTube remedy; elsewhere the arg means
+    nothing and repeating a refused download would only waste time."""
+    provider = YtDlpProvider()
+    recorder = _Recorder(tmp_path, failures=99)
+    monkeypatch.setattr(
+        YtDlpProvider, "_run", lambda self, args, ctx: recorder(args, ctx)
+    )
+
+    with pytest.raises(StepExecutionError):
+        provider._acquire_audio(
+            _step("https://example.com/a.mp3"), _ctx(tmp_path, settings)
+        )
+
+    assert recorder.clients == [""]


### PR DESCRIPTION
One HomeTube run asked a YouTube URL for video and audio. The video succeeded; the audio — asking for the same opus stream seconds later — was refused with HTTP 403 and the job failed. Replaying the identical command minutes later succeeded, so the refusal was transient: a media URL is signed and short-lived, and every yt-dlp invocation re-extracts it.

Video had carried a fallback ladder since the beginning (codec profiles × player clients) and recovered from that class of refusal without anyone noticing. Audio had a single shot. It now shares the standard, with the default client tried twice before any alternative: measured, `ios` and `web` cannot serve audio-only formats for this video at all ("only images are available" without a PO token), so reaching for them before a plain retry would replace a recoverable blip with a different failure. Cancellation and timeouts still stop immediately — they are decisions, not hiccups — and a non-YouTube source keeps its single attempt.

Provenance records the retry, so an operator comparing two runs need not guess why one was slower or came from another client. Verified against the live engine: the exact failing request now succeeds for both outputs.

The deeper waste this exposed — video+audio downloading the same stream twice, when the audio artifact could be extracted losslessly from the video already on disk — is recorded as D-57 rather than fixed here; it is a planning change that deserves its own slice.