### PR TITLE
version-tag: offer to push, and refuse the two tags that went wrong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,20 @@ version-tag:  ## Create the annotated tag v<version> (clean tree required; asks 
 	  echo "  2. make version-tag         back here, on the updated main"; \
 	  exit 1; \
 	fi; \
+	if [ ! -f "docs/releases/v$$v.md" ]; then \
+	  echo "docs/releases/v$$v.md is missing — the release draft uses it as its"; \
+	  echo "body and silently falls back to a bare commit list without it."; \
+	  echo "Write the notes with the release, then tag."; \
+	  exit 1; \
+	fi; \
+	git fetch -q origin main 2>/dev/null || true; \
+	if git rev-parse -q --verify origin/main >/dev/null \
+	   && ! git merge-base --is-ancestor HEAD origin/main; then \
+	  echo "HEAD is not on origin/main — merge first, then tag the merged commit."; \
+	  echo "(v0.3.0 was tagged on an unmerged commit: the tag's tree had no"; \
+	  echo " release notes and the published notes advertised a 404.)"; \
+	  exit 1; \
+	fi; \
 	printf 'create annotated tag v%s at %s (%s)? [y/N] ' \
 	  "$$v" "$$(git rev-parse --short HEAD)" "$$(git branch --show-current)"; \
 	read -r answer; \
@@ -191,7 +205,19 @@ version-tag:  ## Create the annotated tag v<version> (clean tree required; asks 
 	  *) echo "aborted — no tag created"; exit 1;; \
 	esac; \
 	git tag -a "v$$v" -m "Content v$$v"; \
-	echo "tag v$$v created — push it deliberately with: git push origin v$$v"
+	echo "tag v$$v created."; \
+	echo; \
+	echo "Pushing it starts the release: CI, the four GHCR images, and a draft"; \
+	echo "release with the wheels, the extension zip and your notes attached."; \
+	echo "Nothing is published — the draft waits for you."; \
+	printf 'push v%s to origin now? [y/N] ' "$$v"; \
+	read -r push; \
+	case "$$push" in \
+	  [yY]*) \
+	    git push origin "v$$v" && \
+	    echo "pushed — follow it in Actions, then publish the draft release";; \
+	  *) echo "kept local — push it when ready with: git push origin v$$v";; \
+	esac
 
 # --- python distributions ---------------------------------------------------------
 


### PR DESCRIPTION
Creating the tag and pushing it are one intention split across two commands, and the second was easy to forget or to run from the wrong place. version-tag now offers the push, stating plainly what it starts — CI, the four images, a draft release — and that nothing is published without a further decision. Declining keeps the tag local and prints the command.

Two guards come with it, each one a release that actually went wrong. v0.3.0 was tagged on a commit that was never merged: the tag's tree had no release notes, the draft fell back to a bare commit list, and the published notes advertised a URL that 404'd. Tagging now refuses when HEAD is not an ancestor of origin/main, and when
docs/releases/v<version>.md is absent — the file the draft uses as its body, whose absence is silent.

Verified against a throwaway remote: the tag is created and kept local on a declined push, pushed on an accepted one, and refused outright for an unmerged HEAD or missing notes.