### PR TITLE
HomeTube: keep the sidebar reachable, collapsed on purpose

### DIFF
--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -130,14 +130,24 @@ def _reason_text(reason: dict | None) -> str:
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 
-st.set_page_config(page_title="HomeTube", page_icon="🎬", layout="centered")
+# The sidebar (status, recent jobs) starts collapsed on purpose: HomeTube's
+# value is the single centered form. Collapsed, not gone — the header keeps
+# the toggle that reopens it.
+st.set_page_config(
+    page_title="HomeTube",
+    page_icon="🎬",
+    layout="centered",
+    initial_sidebar_state="collapsed",
+)
 
 st.markdown(
     """
     <style>
-      /* Remove Streamlit's top toolbar/decoration ribbon — it added a dark
-         band that clipped the logo and served no purpose for this app. */
-      header[data-testid="stHeader"] { display: none; }
+      /* Streamlit's header ribbon added a dark band that clipped the logo —
+         but `display: none` also removed the sidebar TOGGLE that lives in
+         it, leaving the collapsed sidebar unreachable. Transparent keeps the
+         control and loses the band. */
+      header[data-testid="stHeader"] { background: transparent; }
       div[data-testid="stDecoration"] { display: none; }
       #MainMenu, footer { visibility: hidden; }
       .block-container { padding-top: 1.5rem; padding-bottom: 3rem;


### PR DESCRIPTION
The sidebar looked missing. It never was — app.py builds one (backend status, the API link, the AGPL source offer, recent jobs) exactly like Studio and the Console. The cause was our own CSS: hiding Streamlit's header ribbon with display:none also removed the sidebar toggle that lives inside it, so once the sidebar collapsed — which layout="centered" does by itself on narrower viewports — nothing on screen could reopen it.

The header is now transparent instead of gone: the dark band that clipped the logo stays away, the toggle stays clickable. And the collapse becomes a decision rather than an accident of viewport width — initial_sidebar_state="collapsed", because HomeTube's value is the single centered form and the sidebar is secondary.

Studio and the Console never hid their headers, which is why their sidebars always worked; they are untouched. The rebuilt image serves both changes (verified in the running container); the toggle's look needs one human glance at http://localhost:8501, which this change awaits before merge.