### PR TITLE
Release notes for 0.4.0

### DIFF
--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,86 @@
+A presentation release. The engine is untouched — no planner, provider or
+contract change — and what moved is how the project explains itself, plus the
+three things a visitor touches on the way in: the README, HomeTube's sidebar,
+and the browser extension.
+
+## The README introduces Content, not just its features
+
+Content had been describing what it *is* before showing what it *does*, which
+asks a stranger to care before they understand. The page now opens on the
+result — URLs, files and text turned into media, transcripts, summaries,
+translations, images, Markdown and PDF — and only then explains the machinery.
+
+The relationship with HomeTube is stated plainly rather than left to be
+inferred: **HomeTube is the focused YouTube door, Content is the engine behind
+it**, with Content Studio for general workflows and the same backend answering
+the REST API, the MCP server, the CLI, the browser extension and the typed
+Python SDK. A visitor arriving for a YouTube downloader can start exactly where
+they are and discover the rest when they need it; a visitor arriving for an
+engine no longer has to guess whether this is "another yt-dlp wrapper". Section
+links at the top let each of them jump to their own entry point.
+
+## HomeTube: the sidebar is reachable again
+
+The sidebar looked missing. It never was — backend status, the API link, the
+AGPL source offer and recent jobs were always built. The cause was HomeTube's
+own CSS: hiding Streamlit's header ribbon with `display: none` also removed the
+sidebar toggle that lives inside it, so once the sidebar collapsed — which a
+centered layout does by itself on narrower viewports — nothing on screen could
+reopen it.
+
+The header is now transparent instead of gone: the dark band that clipped the
+logo stays away, the toggle stays clickable. And the collapse became a decision
+rather than an accident of viewport width, because HomeTube's value is the
+single centered form and the sidebar is secondary. Studio and the Console never
+hid their headers, which is why their sidebars always worked; they are
+unchanged.
+
+## The extension says which engine it is talking to
+
+The backend address was already configurable — settings page, permission flow,
+connection test, all present — and its first real user could not find it. For
+someone who cannot find it, an invisible setting and a missing one are the same
+thing.
+
+The popup now ends with a quiet line naming the engine it targets
+(`192.168.21.30:8010`, say), on every view, and clicking it opens the settings:
+"where is this sending my video?" is answered on screen rather than two clicks
+away. The options page calls it *Address* under the existing *Engine* legend,
+so every surface uses one word for one thing. A guard-rail test keeps the line
+wired to the configured address.
+
+## Releasing is written down
+
+The guards landed over the previous releases — refuse to tag a commit that is
+not on `origin/main`, refuse when the release notes file is missing, refuse a
+re-tag, require a clean tree, and offer to push the tag with its consequences
+stated. What was missing was the process those guards protect.
+
+[docs/operations/releasing.md](../operations/releasing.md) is now the whole
+sequence in order, marked by actor — the shell, the browser, and what the tag
+triggers by itself — followed by the two judgement calls (when TestPyPI earns
+its place, and why a version number is spent forever on whichever index it
+touches) and the recovery paths for the four failures that actually happened:
+a tag on the wrong commit, a half-merged release branch, a draft built without
+its notes, and a publish that stops midway. Each is labelled undoable or not,
+around one rule: everything before the PyPI run can be walked back, nothing
+after it can.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+The engine's behaviour is identical to 0.3.3, so this upgrade carries no
+migration and no risk to running jobs. HomeTube starts with its sidebar
+collapsed and its toggle usable.
+
+Browser-extension users: download the new zip from this release, unzip it over
+the existing folder and press ↻ on the extension card — settings and granted
+host permissions are preserved.
+
+CLI and MCP users: `uv tool install --reinstall content-cli content-mcp` once
+the packages are published.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.3.3...v0.4.0


### PR DESCRIPTION
The tag guard refused v0.4.0 because docs/releases/v0.4.0.md was missing — working exactly as intended: without the file the draft release silently falls back to a bare commit list, which is how v0.3.0 shipped notes nobody wrote.

The notes describe what this release actually is: a presentation release with no engine change. The README introducing Content and stating the HomeTube relationship plainly, HomeTube's sidebar toggle surviving the hidden header, the extension naming the engine it targets, and the release process itself being written down. Member concurrency is not mentioned — it is not merged, so it is not in this tag.