### PR TITLE
Document how to configure HomeTube

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ CONTENT_WHISPER_MODEL=small
 # VO_FIRST), then the primary language, then the secondaries — keeping only what
 # a source actually offers. (ex-HomeTube LANGUAGE_PRIMARY / LANGUAGES_SECONDARIES
 # / VO_FIRST / LANGUAGE_PRIMARY_INCLUDE_SUBTITLES.)
+#
+# The last one ships as `false` while the engine's own default is `true`:
+# someone fluent in the primary language rarely wants subtitles in it, but
+# still wants the secondaries. It excludes ONLY the primary. A worked example
+# of all four is in apps/web-hometube/README.md.
 CONTENT_LANGUAGE_PRIMARY=fr
 CONTENT_LANGUAGES_SECONDARIES=en,es
 CONTENT_VO_FIRST=true

--- a/README.md
+++ b/README.md
@@ -75,6 +75,47 @@ sources, and it does not expose the broader document workflow or PDF output.
 For those workflows, use Content Studio, the API, CLI, or SDK. **HomeTube is a
 Content client, not a layer every Content user must pass through.**
 
+### Configuring HomeTube
+
+HomeTube has no settings of its own: it reads the engine's configuration, so
+everything below goes in the `.env` next to your `docker-compose.yml`. These
+are the ones that change what you see; the
+[full table](docs/operations/deployment.md#configuration-a-root-env-not-versioned)
+lists every variable.
+
+| Variable | Default | What it changes in HomeTube |
+| --- | --- | --- |
+| `CONTENT_DELIVERY_DIR_HOST` | `./playground/output` | Where finished files land. Point it at your Plex/Jellyfin/Emby library and its sub-folders become the destination choices in the form |
+| `CONTENT_LANGUAGE_PRIMARY` | — | The language you speak: first in the audio order and pre-selected |
+| `CONTENT_LANGUAGES_SECONDARIES` | — | `en,es` — offered and pre-selected after the primary |
+| `CONTENT_VO_FIRST` | `true` | Put the original voice ahead of your own language |
+| `CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES` | `true` (the shipped `.env` sets `false`) | Whether your primary language is also pre-checked in the subtitle list |
+| `CONTENT_CREDENTIALS` | — | `youtube=/config/cookies.txt` — a cookie file for age-restricted or members-only videos. The file never leaves the server; HomeTube only shows its id |
+| `COMPOSE_PROFILES` | `hometube,studio` | Which UIs start. `hometube` alone runs HomeTube only |
+| `HOMETUBE_PORT` | `8501` | The host port HomeTube listens on |
+
+**What the language settings actually do**, since the effect is easier to read
+than the rule. With:
+
+```bash
+CONTENT_LANGUAGE_PRIMARY=fr
+CONTENT_LANGUAGES_SECONDARIES=en,es
+CONTENT_VO_FIRST=true
+CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES=false
+```
+
+on a Japanese talk that offers `ja`/`en` audio and `ja`/`fr`/`en`/`de`
+subtitles, HomeTube shows **audio** ordered `ja, en` — the original voice
+first because `VO_FIRST` is on, then your languages — with both pre-selected.
+For **subtitles** it pre-checks `en` only: the original voice never applies to
+subtitles, `de` is not one of your languages, and `fr` is left out because
+`…_INCLUDED_IN_SUBTITLES=false` — someone fluent in French does not need French
+subtitles but still wants the English ones. Set it to `true` and `fr, en` are
+both pre-checked.
+
+Nothing is ever pre-selected that the source does not actually offer, and every
+default remains editable in the form before you launch the job.
+
 ## One source, many artifacts
 
 The same engine serves media and document workflows:

--- a/apps/web-hometube/README.md
+++ b/apps/web-hometube/README.md
@@ -1,14 +1,89 @@
-# HomeTube — the Streamlit frontend
+<!-- markdownlint-disable MD033 -->
 
-A **client** of the Content API (`/api/v1`), not the backend. It takes up the
-HomeTube use case (a URL as input) but with Content's versatile outputs (video,
-audio, subtitles, thumbnail, metadata, transcript, summary): paste a URL →
-analyze → choose what you want to extract → launch → follow the job live →
-download the artifacts. No business logic here: the backend validates, plans and
-executes; the UI is **capability-driven** (it renders what `/capabilities`
-resolves) and speaks HTTP only through the SDK (`content_sdk`).
+# HomeTube — the YouTube interface for Content
 
-## Running locally (dev)
+Paste a URL, choose what you want from it, watch the job land in your library.
+
+A **client** of the Content API (`/api/v1`), not a backend. It takes up the
+HomeTube use case (a URL in) with Content's versatile outputs (video, audio,
+subtitles, thumbnail, metadata, transcript, summary): analyze → choose → launch
+→ follow live → find the files in your library. No business logic lives here —
+the engine validates, plans and executes, and the UI is **capability-driven**
+(it renders what `/capabilities` resolves for your source, so a capability the
+engine gains appears on its own). It speaks HTTP only through the SDK
+(`content_sdk`).
+
+## Configuration
+
+**HomeTube has no settings of its own.** Everything it does is driven by the
+engine's configuration, so all of the following goes in the `.env` beside your
+`docker-compose.yml` — never here. The
+[deployment guide](../../docs/operations/deployment.md#configuration-a-root-env-not-versioned)
+lists every variable Content accepts; this table is the subset that changes
+what HomeTube shows you.
+
+| Variable | Default | Effect in HomeTube |
+| --- | --- | --- |
+| `CONTENT_DELIVERY_DIR_HOST` | `./playground/output` | The library finished files are copied into. Its **sub-folders become the destination choices** in the form, so a `Talks/`, `Music/`, `Kids/` layout on your NAS shows up as those options |
+| `CONTENT_LANGUAGE_PRIMARY` | — | The language you speak (`fr`). First in the audio order after the original, and pre-selected |
+| `CONTENT_LANGUAGES_SECONDARIES` | — | Comma-separated (`en,es`). Offered and pre-selected after the primary |
+| `CONTENT_VO_FIRST` | `true` | Put the source's original voice ahead of your own languages |
+| `CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES` | `true` — but the shipped `.env.example` sets `false` | Whether your primary language is also pre-checked among subtitles |
+| `CONTENT_CREDENTIALS` | — | `youtube=/config/cookies.txt`. Unlocks age-restricted, private or members-only videos. HomeTube only ever displays the **id**; the cookie file stays on the server and never enters a request |
+| `COMPOSE_PROFILES` | `hometube,studio` | Which UIs start. Set to `hometube` to run this one alone |
+| `HOMETUBE_PORT` | `8501` | The host port |
+| `CONTENT_DELIVERY_DEFAULT` | `false` (compose: `true`) | Whether every artifact is copied into the library by default |
+
+### Language preferences, by example
+
+The rule is short — original voice (if enabled), then your primary, then your
+secondaries, keeping only what the source actually offers — but the effect is
+easier to read than the rule. With:
+
+```bash
+CONTENT_LANGUAGE_PRIMARY=fr
+CONTENT_LANGUAGES_SECONDARIES=en,es
+CONTENT_VO_FIRST=true
+CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES=false
+```
+
+on a Japanese talk offering `ja`/`en` audio and `ja`/`fr`/`en`/`de` subtitles:
+
+| | What you get | Why |
+| --- | --- | --- |
+| **Audio order** | `ja, en` | The original first (`VO_FIRST=true`), then your languages; `fr` and `es` are dropped because this source has no such track |
+| **Audio pre-selected** | `ja, en` | Everything wanted that exists |
+| **Subtitles pre-checked** | `en` only | The original voice never applies to subtitles; `de` is not one of your languages; `fr` is excluded by `…_INCLUDED_IN_SUBTITLES=false` |
+
+That last flag carries the original HomeTube semantics: someone fluent in
+French does not need French subtitles, but still wants the English and Spanish
+ones. It excludes **only** the primary — the secondaries keep pre-filling. Set
+it to `true` and the subtitles become `fr, en`.
+
+Two invariants worth relying on: nothing is ever pre-selected that the source
+does not offer, and no default is final — everything stays editable in the form
+before you launch.
+
+### Cookies for restricted videos
+
+Put the cookie file where the engine can read it and name it:
+
+```bash
+CONTENT_CREDENTIALS=youtube=/config/youtube_cookies.txt
+```
+
+The compose file already mounts `./config` into the container at `/config`, so
+dropping `youtube_cookies.txt` there and restarting is enough. A credential
+selector then appears in HomeTube, preselecting `youtube` when it exists —
+because cookies all but decide whether a given YouTube download works.
+
+## Running it
+
+With the published images, HomeTube starts as part of the stack (see the
+[Quick start](../../README.md#quick-start)) on <http://localhost:8501>.
+
+<details>
+<summary><b>Running from a clone, for development</b></summary>
 
 The backend must be running (see the repository root). Then:
 
@@ -18,34 +93,13 @@ pip install "streamlit>=1.40" -e ../../packages/python-sdk
 CONTENT_API_URL=http://localhost:8010 streamlit run app.py
 ```
 
-- `CONTENT_API_URL` — the backend URL as seen by the frontend (HTTP requests).
-- `CONTENT_PUBLIC_API_URL` — the backend URL as seen by the **browser** (the
-  artifacts' download links). Defaults to `CONTENT_API_URL`. Under Docker they
-  differ (an internal service name vs a host port).
+- `CONTENT_API_URL` — the backend as seen by **this process** (its HTTP calls).
+- `CONTENT_PUBLIC_API_URL` — the backend as seen by the **browser** (the
+  artifacts' download links). Defaults to `CONTENT_API_URL`. Under Docker the
+  two differ: an internal service name (`http://content:8000`) versus a host
+  port (`http://localhost:8010`).
 
-## Running with Docker (multi-container)
+From the repository root, `docker compose up --build` runs the whole stack
+from source instead.
 
-From the repository root:
-
-```bash
-docker compose up --build
-```
-
-- the backend (`content`) on `http://localhost:8010`, HomeTube (`hometube`) on
-  `http://localhost:8501`.
-- The frontend reaches the backend through `http://content:8000` (the compose
-  network); the download links point at `http://localhost:8010` (the browser).
-
-## Language preferences
-
-Audio tracks and subtitles are **ordered and pre-selected** according to the
-server preferences (`CONTENT_LANGUAGE_PRIMARY`,
-`CONTENT_LANGUAGES_SECONDARIES`, `CONTENT_VO_FIRST`,
-`CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES`) intersected with what the
-source actually offers — never "every track" by default.
-
-## Cookies / authentication
-
-Configure the credentials on the backend side (`CONTENT_CREDENTIALS`); the
-frontend lists them (ids only) and offers a selector. The secret never travels
-through the frontend or the request.
+</details>

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -128,10 +128,13 @@ console are not listed there because they always run.
 | `CONTENT_CACHE_ENABLED` | `false` (compose: `true`) | URL JSON cache + video reuse ([storage.md](../storage.md), ADR 0010) |
 | `CONTENT_ANALYSIS_TTL_HOURS` | `72` | How long a URL analysis is cached (3 days) |
 | **🗣️ Language preferences** | | |
-| `CONTENT_LANGUAGE_PRIMARY` | — | The primary audio language (a client default) |
-| `CONTENT_LANGUAGES_SECONDARIES` | — | Secondary languages `fr,es` (audio + subtitles) |
-| `CONTENT_VO_FIRST` | `true` | Original voice first in the track order |
-| `CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES` | `true` | Include the primary language in the default subtitle selection |
+| `CONTENT_LANGUAGE_PRIMARY` | — | The language this installation speaks. Ordered first (after the original voice) and pre-selected in the UIs, for **audio and subtitles** |
+| `CONTENT_LANGUAGES_SECONDARIES` | — | Secondary languages `en,es` — offered and pre-selected after the primary (audio + subtitles) |
+| `CONTENT_VO_FIRST` | `true` | Original voice ahead of the primary language in the track order |
+| `CONTENT_LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES` | `true` (`.env.example`: `false`) | Whether the primary language is pre-checked among subtitles too. `false` excludes **only** the primary — the secondaries keep pre-filling, because someone fluent in `fr` does not need `fr` subtitles but wants the `en` ones |
+
+A worked example of the four together — what a given source ends up showing —
+is in [HomeTube's README](../../apps/web-hometube/README.md#language-preferences-by-example).
 | **🧠 Providers & LLM runners** | | |
 | `CONTENT_YTDLP_EXTRA_ARGS` | — | The operator's yt-dlp args (trusted), added to every call |
 | `CONTENT_OLLAMA_URL` / `_MODEL` | host / auto | The **local** LLM for `summary`, `translation` and derived `chapters`. Empty model = the first installed one, resolved deterministically and recorded in provenance |


### PR DESCRIPTION
HomeTube is the flagship, and its configuration was documented everywhere except where someone would look for it. The variables were listed in the deployment guide's full table (forty-odd rows, most of them irrelevant to a HomeTube user), the .env.example carried them with a terse comment, and HomeTube's own README described the language rule in one abstract sentence — "ordered and pre-selected according to the server preferences". True, and impossible to predict a result from.

Three places now answer three different questions. The root README gains a "Configuring HomeTube" table: the eight settings that change what you see, and nothing else, since the exhaustive list already exists and two copies of it would drift apart. HomeTube's README is rewritten for the person running it rather than the person developing it — the same table with more room, the cookie setup spelled out, and the dev instructions folded into a details block at the end. The deployment guide keeps the full table, with the language rows corrected.

The language settings are now shown by worked example, because the effect is easier to read than the rule: fr primary, en/es secondaries, VO first, primary excluded from subtitles, applied to a Japanese talk — here is the audio order you get, here is what is pre-checked, and here is why each language was kept or dropped.

Two things that were true but undocumented, and read as bugs when met in the wild: LANGUAGE_PRIMARY_INCLUDED_IN_SUBTITLES defaults to true in the engine while the shipped .env sets false (deliberate — someone fluent in French does not want French subtitles but does want the English ones), and it excludes only the primary, never the secondaries. Both are now stated wherever the variable appears.