### PR TITLE
Collections: run members concurrently, bounded to 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ TZ=Europe/Paris
 CONTENT_MAX_CONCURRENT_JOBS=2
 CONTENT_STEP_TIMEOUT_SECONDS=3600
 
+# How many members of one playlist/collection run at once. A politeness bound
+# toward the provider — 2 concurrent members are 2 concurrent downloads from
+# the same host — not a throughput dial. 1 = strictly one after another.
+CONTENT_COLLECTION_MEMBER_CONCURRENCY=2
+
 # SSRF guard: true allows URLs pointing at private/loopback IPs (local testing).
 CONTENT_ALLOW_PRIVATE_NETWORKS=false
 

--- a/apps/backend/content/config.py
+++ b/apps/backend/content/config.py
@@ -47,6 +47,11 @@ class ContentSettings:
     cache_dir: Path | None = None  # None = <data_dir>/cache
     cache_enabled: bool = False  # V1: no inter-job cache / reuse (ADR 0009)
     max_concurrent_jobs: int = 2
+    # How many members of one collection may execute at once (ADR 0019). A
+    # politeness bound toward the provider, not a throughput feature: two
+    # concurrent members are two concurrent downloads from the same host.
+    # 1 = strictly sequential members.
+    collection_member_concurrency: int = 2
     step_timeout_seconds: int = 3600
     analysis_timeout_seconds: int = 120
     analysis_ttl_hours: float = 72.0  # 3 days — URL info is cached this long
@@ -484,6 +489,9 @@ def settings_from_env() -> ContentSettings:
         cache_enabled=_to_bool(os.getenv("CONTENT_CACHE_ENABLED"), False),
         max_concurrent_jobs=max(
             1, _to_int(os.getenv("CONTENT_MAX_CONCURRENT_JOBS"), 2)
+        ),
+        collection_member_concurrency=max(
+            1, _to_int(os.getenv("CONTENT_COLLECTION_MEMBER_CONCURRENCY"), 2)
         ),
         step_timeout_seconds=_to_int(os.getenv("CONTENT_STEP_TIMEOUT_SECONDS"), 3600),
         analysis_timeout_seconds=_to_int(

--- a/apps/backend/content/execution/executor.py
+++ b/apps/backend/content/execution/executor.py
@@ -9,11 +9,21 @@ gets its products promoted as artifacts (write-then-register — the file is
 moved into artifacts/ before the DB row exists, so a crash can never leave a
 registered-but-missing artifact); an unbound step's products stay in work/ as
 internal materials. A step whose dependency did not succeed is skipped.
+
+Collection members are the one place steps run concurrently (ADR 0019): a run
+of consecutive ``collection.member`` steps — independent by construction, no
+member depends on another — is dispatched to a small thread pool bounded by
+``CONTENT_COLLECTION_MEMBER_CONCURRENCY``. Everything else about a member step
+is the ordinary step lifecycle; the pool only changes *when* members start,
+never what a member is. Every other step keeps the strictly sequential loop.
 """
 
 import json
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
+from content.application.collections import MEMBER_OPERATION
 from content.config import ContentSettings
 from content.domain.job import aggregate_final_status, ensure_step_transition
 from content.domain.plan import ExecutionPlan, PlanStep
@@ -31,6 +41,112 @@ from content.providers.base import (
 from content.storage.layout import DeliveryStore, JobStorage, checksum_sha256
 
 _PROGRESS_MIN_DELTA = 1.0  # percent — event throttling, HomeTube-proven
+
+
+class _RunState:
+    """The mutable state one running job's steps share.
+
+    With member concurrency the executor touches these from a thread pool, so
+    every mutation goes through a method holding the one lock. The lock guards
+    dict/flag work only — never a runner, a file move or a store call (the
+    store is safe on its own: WAL, one short-lived connection per call). Steps
+    never share ids, and member artifact names embed the member's ordinal
+    (``item_slug``), so files cannot collide either — what genuinely needs
+    protection is exactly what is here: the shared counters and flags.
+    """
+
+    def __init__(self, plan: ExecutionPlan, request: GenerationRequest):
+        self._lock = threading.Lock()
+        self._step_status = {step.id: "pending" for step in plan.steps}
+        self._produced_count = {output.id: 0 for output in request.outputs}
+        self._step_materials: dict[str, list[Material]] = {}
+        self._step_artifact_ids: dict[str, list[str]] = {}
+        self._stop_new_steps = False
+
+    def transition(self, step_id: str, target: str) -> None:
+        """Validate and record a step transition (the store write is the
+        caller's, after — the domain rule must hold before anything persists).
+        """
+        with self._lock:
+            ensure_step_transition(self._step_status[step_id], target)
+            self._step_status[step_id] = target
+
+    def status_of(self, step_id: str) -> str:
+        with self._lock:
+            return self._step_status.get(step_id, "pending")
+
+    def unfinished_steps(self) -> list[str]:
+        with self._lock:
+            return [
+                step_id
+                for step_id, status in self._step_status.items()
+                if status in ("pending", "ready")
+            ]
+
+    def record_products(
+        self, step_id: str, materials: list[Material], artifact_ids: list[str]
+    ) -> None:
+        with self._lock:
+            self._step_materials[step_id] = materials
+            self._step_artifact_ids[step_id] = artifact_ids
+
+    def inputs_for(self, step: PlanStep) -> tuple[list[Material], list[str]]:
+        with self._lock:
+            materials = [
+                material
+                for dep in step.depends_on
+                for material in self._step_materials.get(dep, [])
+            ]
+            artifact_ids = [
+                artifact_id
+                for dep in step.depends_on
+                for artifact_id in self._step_artifact_ids.get(dep, [])
+            ]
+        return materials, artifact_ids
+
+    def count_artifact(self, output_id: str) -> None:
+        with self._lock:
+            self._produced_count[output_id] = self._produced_count.get(output_id, 0) + 1
+
+    def produced_counts(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._produced_count)
+
+    def request_stop(self) -> None:
+        with self._lock:
+            self._stop_new_steps = True
+
+    @property
+    def stopping(self) -> bool:
+        with self._lock:
+            return self._stop_new_steps
+
+
+def _dispatch_groups(steps: list[PlanStep], member_limit: int):
+    """Split the ordered plan into dispatch groups.
+
+    Runs of consecutive collection-member steps become one group the executor
+    may run concurrently; every other step is a group of one, executed exactly
+    as it always was. With a limit of 1 everything is a group of one — the
+    sequential executor, unchanged. The ``depends_on`` guard is defensive: the
+    planner never gives a member step dependencies, and a step that somehow
+    had them must stay in the ordered sequential flow.
+    """
+    group: list[PlanStep] = []
+    for step in steps:
+        if (
+            member_limit > 1
+            and step.operation == MEMBER_OPERATION
+            and not step.depends_on
+        ):
+            group.append(step)
+            continue
+        if group:
+            yield group
+            group = []
+        yield [step]
+    if group:
+        yield group
 
 
 class JobExecutor:
@@ -70,11 +186,7 @@ class JobExecutor:
         max_runtime = request.constraints.resources.max_runtime_seconds
         deadline = time.monotonic() + max_runtime if max_runtime else None
         outputs_by_id = {output.id: output for output in request.outputs}
-        produced_count: dict[str, int] = {output.id: 0 for output in request.outputs}
-        step_status: dict[str, str] = {step.id: "pending" for step in plan.steps}
-        step_materials: dict[str, list[Material]] = {}
-        step_artifact_ids: dict[str, list[str]] = {}
-        stop_new_steps = False
+        state = _RunState(plan, request)
 
         # Inter-job reuse is a cache feature: inert unless the cache is enabled
         # (ADR 0009). reuse_existing=true is accepted but has no effect in V1.
@@ -82,115 +194,37 @@ class JobExecutor:
             self._settings.cache_enabled and request.execution.reuse_existing
         )
 
-        for step in plan.ordered_steps():
-            if self._store.is_cancel_requested(job_id):
-                self._finish_cancelled(job_id, plan, step_status, storage)
-                return
-
-            # Reuse is checked before the dependency gate: cached work stands
-            # on its own (the signature covers the whole upstream chain).
-            reused = (
-                self._find_reusable(job_id, step)
-                if reuse_enabled and plan.bindings_for_step(step.id)
-                else None
-            )
-
-            failed_deps = [
-                dep for dep in step.depends_on if step_status.get(dep) != "succeeded"
-            ]
-            budget_exhausted = deadline is not None and time.monotonic() > deadline
-            if stop_new_steps or budget_exhausted or (failed_deps and reused is None):
-                if budget_exhausted:
-                    reason = "job runtime budget exhausted"
-                elif failed_deps:
-                    reason = f"dependency did not succeed: {', '.join(failed_deps)}"
-                else:
-                    reason = "skipped by fail_fast policy"
-                self._move_step(job_id, step.id, step_status, "skipped")
-                self._events.publish(
-                    job_id, "step.skipped", {"step_id": step.id, "reason": reason}
-                )
-                continue
-
-            inputs = [
-                material
-                for dep in step.depends_on
-                for material in step_materials.get(dep, [])
-            ]
-            parent_artifact_ids = [
-                artifact_id
-                for dep in step.depends_on
-                for artifact_id in step_artifact_ids.get(dep, [])
-            ]
-
-            self._move_step(job_id, step.id, step_status, "ready")
-            self._move_step(
-                job_id, step.id, step_status, "running", started_at=utcnow()
-            )
-            self._events.publish(job_id, "step.started", {"step_id": step.id})
-
-            try:
-                if reused is not None:
-                    produced, reused_from_job, producer_override = reused
-                    promote_mode = "copy"
-                else:
-                    produced = self._run_step(job_id, step, storage, deadline, inputs)
-                    reused_from_job, producer_override = "", None
-                    promote_mode = "move"
-                artifact_ids, materials = self._register_products(
+        member_limit = max(1, self._settings.collection_member_concurrency)
+        for group in _dispatch_groups(list(plan.ordered_steps()), member_limit):
+            if len(group) == 1:
+                outcome = self._advance_step(
                     job_id,
-                    step,
+                    group[0],
                     plan,
-                    produced,
                     request,
                     storage,
-                    parent_artifact_ids,
-                    produced_count,
-                    promote_mode=promote_mode,
-                    producer_override=producer_override,
+                    deadline,
+                    state,
+                    reuse_enabled,
                 )
-            except StepExecutionError as exc:
-                if exc.code == "cancelled" or self._store.is_cancel_requested(job_id):
-                    self._move_step(
-                        job_id, step.id, step_status, "cancelled", finished_at=utcnow()
-                    )
-                    self._finish_cancelled(job_id, plan, step_status, storage)
-                    return
-                self._move_step(
+                cancelled = outcome == "cancelled"
+            else:
+                cancelled = self._run_member_group(
                     job_id,
-                    step.id,
-                    step_status,
-                    "failed",
-                    error=f"{exc.code}: {exc}",
-                    finished_at=utcnow(),
+                    group,
+                    plan,
+                    request,
+                    storage,
+                    deadline,
+                    state,
+                    reuse_enabled,
+                    member_limit,
                 )
-                self._events.publish(
-                    job_id,
-                    "step.failed",
-                    {
-                        "step_id": step.id,
-                        "code": exc.code,
-                        "message": str(exc),
-                        # Machine-readable context when the failure has some;
-                        # absent rather than empty so consumers can tell the
-                        # difference between "none" and "not reported".
-                        **({"details": exc.details} if exc.details else {}),
-                    },
-                )
-                if policy == "fail_fast" and step.required:
-                    stop_new_steps = True
-                continue
+            if cancelled:
+                self._finish_cancelled(job_id, plan, state, storage)
+                return
 
-            step_materials[step.id] = materials
-            step_artifact_ids[step.id] = artifact_ids
-            self._move_step(
-                job_id, step.id, step_status, "succeeded", finished_at=utcnow()
-            )
-            succeeded_data = {"step_id": step.id, "artifact_ids": artifact_ids}
-            if reused is not None:
-                succeeded_data["reused_from_job"] = reused_from_job
-            self._events.publish(job_id, "step.succeeded", succeeded_data)
-
+        produced_count = state.produced_counts()
         required_missing = any(
             count == 0 and outputs_by_id[output_id].required
             for output_id, count in produced_count.items()
@@ -208,6 +242,164 @@ class JobExecutor:
         storage.write_snapshot("result", {"status": final, "outputs": produced_count})
         storage.purge_work()
         storage.purge_tmp()
+
+    def _run_member_group(
+        self,
+        job_id: str,
+        group: list[PlanStep],
+        plan: ExecutionPlan,
+        request: GenerationRequest,
+        storage: JobStorage,
+        deadline: float | None,
+        state: _RunState,
+        reuse_enabled: bool,
+        member_limit: int,
+    ) -> bool:
+        """Run one group of member steps with bounded concurrency; True means
+        cancellation was observed and the job must finish as cancelled.
+
+        The bound is a politeness limit toward the provider, not a throughput
+        feature: two concurrent members are two concurrent downloads from the
+        same host. On cancellation, in-flight members stop through their own
+        ``cancel_check`` and everything not yet started stays pending for
+        ``_finish_cancelled`` to sweep — the same shape the sequential path
+        leaves behind. ``fail_fast`` stops members that have not started;
+        members already in flight run to completion (a valid artifact is never
+        thrown away mid-download) — see ADR 0019.
+        """
+        outcomes: list[str] = []
+        workers = min(member_limit, len(group))
+        with ThreadPoolExecutor(
+            max_workers=workers, thread_name_prefix=f"{job_id}-member"
+        ) as pool:
+            outcomes = list(
+                pool.map(
+                    lambda step: self._advance_step(
+                        job_id,
+                        step,
+                        plan,
+                        request,
+                        storage,
+                        deadline,
+                        state,
+                        reuse_enabled,
+                    ),
+                    group,
+                )
+            )
+        return "cancelled" in outcomes
+
+    def _advance_step(
+        self,
+        job_id: str,
+        step: PlanStep,
+        plan: ExecutionPlan,
+        request: GenerationRequest,
+        storage: JobStorage,
+        deadline: float | None,
+        state: _RunState,
+        reuse_enabled: bool,
+    ) -> str:
+        """One step through its full lifecycle: gate, run, register, settle.
+
+        Returns ``"cancelled"`` the moment cancellation is observed — the step
+        (if it started) is already moved to cancelled, but the *job* is not
+        finalized here: the caller does that once, after any concurrent
+        siblings have wound down. Every other outcome ("succeeded", "failed",
+        "skipped") is fully settled on return.
+        """
+        if self._store.is_cancel_requested(job_id):
+            return "cancelled"
+
+        # Reuse is checked before the dependency gate: cached work stands
+        # on its own (the signature covers the whole upstream chain).
+        reused = (
+            self._find_reusable(job_id, step)
+            if reuse_enabled and plan.bindings_for_step(step.id)
+            else None
+        )
+
+        failed_deps = [
+            dep for dep in step.depends_on if state.status_of(dep) != "succeeded"
+        ]
+        budget_exhausted = deadline is not None and time.monotonic() > deadline
+        if state.stopping or budget_exhausted or (failed_deps and reused is None):
+            if budget_exhausted:
+                reason = "job runtime budget exhausted"
+            elif failed_deps:
+                reason = f"dependency did not succeed: {', '.join(failed_deps)}"
+            else:
+                reason = "skipped by fail_fast policy"
+            self._move_step(job_id, step.id, state, "skipped")
+            self._events.publish(
+                job_id, "step.skipped", {"step_id": step.id, "reason": reason}
+            )
+            return "skipped"
+
+        inputs, parent_artifact_ids = state.inputs_for(step)
+
+        self._move_step(job_id, step.id, state, "ready")
+        self._move_step(job_id, step.id, state, "running", started_at=utcnow())
+        self._events.publish(job_id, "step.started", {"step_id": step.id})
+
+        try:
+            if reused is not None:
+                produced, reused_from_job, producer_override = reused
+                promote_mode = "copy"
+            else:
+                produced = self._run_step(job_id, step, storage, deadline, inputs)
+                reused_from_job, producer_override = "", None
+                promote_mode = "move"
+            artifact_ids, materials = self._register_products(
+                job_id,
+                step,
+                plan,
+                produced,
+                request,
+                storage,
+                parent_artifact_ids,
+                state,
+                promote_mode=promote_mode,
+                producer_override=producer_override,
+            )
+        except StepExecutionError as exc:
+            if exc.code == "cancelled" or self._store.is_cancel_requested(job_id):
+                self._move_step(
+                    job_id, step.id, state, "cancelled", finished_at=utcnow()
+                )
+                return "cancelled"
+            self._move_step(
+                job_id,
+                step.id,
+                state,
+                "failed",
+                error=f"{exc.code}: {exc}",
+                finished_at=utcnow(),
+            )
+            self._events.publish(
+                job_id,
+                "step.failed",
+                {
+                    "step_id": step.id,
+                    "code": exc.code,
+                    "message": str(exc),
+                    # Machine-readable context when the failure has some;
+                    # absent rather than empty so consumers can tell the
+                    # difference between "none" and "not reported".
+                    **({"details": exc.details} if exc.details else {}),
+                },
+            )
+            if request.execution.failure_policy == "fail_fast" and step.required:
+                state.request_stop()
+            return "failed"
+
+        state.record_products(step.id, materials, artifact_ids)
+        self._move_step(job_id, step.id, state, "succeeded", finished_at=utcnow())
+        succeeded_data = {"step_id": step.id, "artifact_ids": artifact_ids}
+        if reused is not None:
+            succeeded_data["reused_from_job"] = reused_from_job
+        self._events.publish(job_id, "step.succeeded", succeeded_data)
+        return "succeeded"
 
     def _run_step(
         self,
@@ -286,7 +478,7 @@ class JobExecutor:
         request: GenerationRequest,
         storage: JobStorage,
         parent_artifact_ids: list[str],
-        produced_count: dict[str, int],
+        state: _RunState,
         *,
         promote_mode: str = "move",
         producer_override: dict | None = None,
@@ -363,7 +555,7 @@ class JobExecutor:
                     producer_override,
                     display_filename,
                 )
-                produced_count[output.id] = produced_count.get(output.id, 0) + 1
+                state.count_artifact(output.id)
                 all_artifact_ids.append(artifact_id)
                 delivered = self._deliver_artifact(
                     plan, output, target, display_filename
@@ -477,24 +669,24 @@ class JobExecutor:
         self,
         job_id: str,
         step_id: str,
-        step_status: dict[str, str],
+        state: _RunState,
         target: str,
         **fields,
     ) -> None:
-        ensure_step_transition(step_status[step_id], target)
-        step_status[step_id] = target
+        state.transition(step_id, target)
         self._store.update_step(job_id, step_id, status=target, **fields)
 
     def _finish_cancelled(
         self,
         job_id: str,
         plan: ExecutionPlan,
-        step_status: dict[str, str],
+        state: _RunState,
         storage: JobStorage,
     ) -> None:
+        unfinished = set(state.unfinished_steps())
         for step in plan.steps:
-            if step_status[step.id] in ("pending", "ready"):
-                self._move_step(job_id, step.id, step_status, "cancelled")
+            if step.id in unfinished:
+                self._move_step(job_id, step.id, state, "cancelled")
         self._store.transition_job(job_id, "cancelled", finished_at=utcnow())
         self._events.publish(job_id, "job.cancelled", {})
         storage.purge_work()

--- a/apps/backend/tests/test_member_concurrency.py
+++ b/apps/backend/tests/test_member_concurrency.py
@@ -1,0 +1,297 @@
+"""Bounded concurrency for collection members (ADR 0019).
+
+The executor dispatches a run of consecutive ``collection.member`` steps to a
+small thread pool sized by ``CONTENT_COLLECTION_MEMBER_CONCURRENCY`` (default
+2 — a politeness bound toward the provider, not a throughput feature). What
+these tests pin down is that everything the sequential executor guaranteed
+survives two members in flight: really-concurrent dispatch, isolated
+workdirs, attributable progress, prompt cancellation, unchanged
+failure-policy semantics, and one step log per member.
+
+The overlap proofs use a ``threading.Barrier`` both members must reach
+*inside* the provider: it can only be crossed when the members are in flight
+at the same time, so a silently-sequential executor breaks the barrier
+instead of silently passing.
+"""
+
+import dataclasses
+import threading
+import time
+
+from content.analysis.service import AnalysisService
+from content.application.submit import submit_generation
+from content.domain.analysis import CollectionEntry
+from content.execution.executor import JobExecutor
+from content.providers.base import StepExecutionError
+from tests.conftest import FakeProvider, make_request, minimal_payload
+
+_BARRIER_TIMEOUT = 10.0  # generous; only ever waited out by a real regression
+
+
+def _each_item_video_payload(**overrides) -> dict:
+    return minimal_payload(
+        sources=[
+            {"id": "main", "type": "url", "uri": "https://example.com/playlist?list=X"}
+        ],
+        outputs=[{"id": "vid", "type": "video", "scope": "each_item"}],
+        **overrides,
+    )
+
+
+def _pipeline(store, providers, settings):
+    """submit → claim → execute, like the API worker would."""
+    service = AnalysisService(store, providers, settings)
+    executor = JobExecutor(store, settings, providers)
+
+    def run(payload: dict) -> str:
+        request = make_request(payload)
+        result = submit_generation(
+            payload,
+            request,
+            store=store,
+            settings=settings,
+            providers=providers,
+            analysis_service=service,
+        )
+        executor.execute(store.claim_next_queued())
+        return result.job_id
+
+    return run
+
+
+def test_two_members_really_run_at_the_same_time(
+    store, providers, settings, monkeypatch
+):
+    """The barrier is crossed only if both members are in flight together —
+    and their workdirs must be distinct while they are (the prerequisite that
+    made concurrency safe, now exercised on the concurrent path itself)."""
+    barrier = threading.Barrier(2)
+    workdirs: dict[str, object] = {}
+    original = FakeProvider.execute
+
+    def meet_in_the_middle(self, step, ctx):
+        workdirs[step.params.get("uri", "")] = ctx.workdir
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        return original(self, step, ctx)
+
+    monkeypatch.setattr(FakeProvider, "execute", meet_in_the_middle)
+
+    job_id = _pipeline(store, providers, settings)(_each_item_video_payload())
+
+    assert store.get_job(job_id)["status"] == "succeeded"
+    assert len(store.list_artifacts(job_id)) == 2
+    assert len(set(workdirs.values())) == 2, "concurrent members shared a workdir"
+
+
+def test_a_limit_of_one_keeps_members_strictly_sequential(
+    store, providers, settings, monkeypatch
+):
+    """Setting the bound to 1 must restore the sequential executor exactly:
+    the two members' execution intervals may not overlap."""
+    sequential = dataclasses.replace(settings, collection_member_concurrency=1)
+    intervals: list[tuple[float, float]] = []
+    original = FakeProvider.execute
+
+    def record_interval(self, step, ctx):
+        start = time.monotonic()
+        try:
+            return original(self, step, ctx)
+        finally:
+            intervals.append((start, time.monotonic()))
+
+    monkeypatch.setattr(FakeProvider, "execute", record_interval)
+
+    job_id = _pipeline(store, providers, sequential)(_each_item_video_payload())
+
+    assert store.get_job(job_id)["status"] == "succeeded"
+    assert len(intervals) == 2
+    first, second = sorted(intervals)
+    assert first[1] <= second[0], "members overlapped despite a limit of 1"
+
+
+def test_progress_stays_attributable_with_members_in_flight(
+    store, providers, settings, monkeypatch
+):
+    """Interleaved progress must still say which member it belongs to: every
+    ``step.progress`` event carries the member step's id, and no event of one
+    member reports another member's message ("3/6 · Title · 73%" depends on
+    exactly this)."""
+    barrier = threading.Barrier(2)
+    original = FakeProvider.execute
+
+    def report_progress(self, step, ctx):
+        uri = step.params.get("uri", "")
+        barrier.wait(timeout=_BARRIER_TIMEOUT)  # both members mid-flight
+        ctx.on_progress(33.0, f"downloading {uri}")
+        ctx.on_progress(66.0, f"downloading {uri}")
+        return original(self, step, ctx)
+
+    monkeypatch.setattr(FakeProvider, "execute", report_progress)
+
+    job_id = _pipeline(store, providers, settings)(_each_item_video_payload())
+
+    progress = [
+        event["data"]
+        for event in store.list_events(job_id)
+        if event["type"] == "step.progress"
+    ]
+    by_step: dict[str, set[str]] = {}
+    for data in progress:
+        by_step.setdefault(data["step_id"], set()).add(data["message"])
+    assert len(by_step) == 2, "each member must report under its own step id"
+    for messages in by_step.values():
+        uris = {message.removeprefix("downloading ") for message in messages}
+        assert len(uris) == 1, f"one step id carries two members' progress: {messages}"
+
+
+def test_cancellation_reaches_members_in_flight(
+    store, providers, settings, monkeypatch
+):
+    """A cancel requested while both members are downloading stops them
+    through their own ``cancel_check`` — the job finishes cancelled, and no
+    member's work is registered as an artifact."""
+    barrier = threading.Barrier(2)
+    job_ref: dict[str, str] = {}
+
+    def cancel_midway(self, step, ctx):
+        barrier.wait(timeout=_BARRIER_TIMEOUT)  # both members are in flight
+        # Both members flip the flag (idempotent), exactly as an API cancel
+        # arriving mid-download would look to each of them.
+        store.request_cancel(job_ref["id"])
+        deadline = time.monotonic() + _BARRIER_TIMEOUT
+        while not ctx.cancel_check():
+            assert time.monotonic() < deadline, "cancel never reached the member"
+            time.sleep(0.01)
+        raise StepExecutionError("cancelled", "stopped by request")
+
+    monkeypatch.setattr(FakeProvider, "execute", cancel_midway)
+
+    # Submit and execute in two beats so the job id is known to the provider
+    # closure before any member starts.
+    service = AnalysisService(store, providers, settings)
+    executor = JobExecutor(store, settings, providers)
+    payload = _each_item_video_payload()
+    result = submit_generation(
+        payload,
+        make_request(payload),
+        store=store,
+        settings=settings,
+        providers=providers,
+        analysis_service=service,
+    )
+    job_ref["id"] = result.job_id
+    executor.execute(store.claim_next_queued())
+
+    assert store.get_job(result.job_id)["status"] == "cancelled"
+    assert store.list_artifacts(result.job_id) == []
+    statuses = {step["status"] for step in store.list_steps(result.job_id)}
+    assert statuses == {"cancelled"}, statuses
+
+
+def test_fail_fast_lets_running_members_finish_and_starts_no_new_ones(
+    store, providers, settings, monkeypatch
+):
+    """The decided semantics for ``fail_fast`` under concurrency: a failing
+    required member stops members that have not started, while a member
+    already downloading runs to completion — its artifact is valid work and is
+    kept. With three members and a bound of 2: member 1 fails, member 2 (in
+    flight when the failure lands) still succeeds, member 3 never starts."""
+    barrier = threading.Barrier(2)
+    original_execute = FakeProvider.execute
+    original_analyze = FakeProvider.analyze
+
+    def analyze_with_three_members(self, source, ctx):
+        analysis = original_analyze(self, source, ctx)
+        if analysis.resource.resource_type == "collection":
+            analysis.entries.append(
+                CollectionEntry(id="v3", title="Third", url="https://x/v3")
+            )
+        return analysis
+
+    def first_fails_while_second_runs(self, step, ctx):
+        uri = step.params.get("uri", "")
+        if uri.endswith("/v1"):
+            barrier.wait(timeout=_BARRIER_TIMEOUT)  # member 2 is in flight
+            raise StepExecutionError("provider_error", "simulated member failure")
+        if uri.endswith("/v2"):
+            barrier.wait(timeout=_BARRIER_TIMEOUT)
+            time.sleep(0.05)  # still running when member 1's failure lands
+        return original_execute(self, step, ctx)
+
+    monkeypatch.setattr(FakeProvider, "analyze", analyze_with_three_members)
+    monkeypatch.setattr(FakeProvider, "execute", first_fails_while_second_runs)
+
+    job_id = _pipeline(store, providers, settings)(
+        _each_item_video_payload(execution={"failure_policy": "fail_fast"})
+    )
+
+    artifacts = store.list_artifacts(job_id)
+    assert len(artifacts) == 1, "the member already in flight keeps its artifact"
+    assert artifacts[0]["provenance"]["attributes"]["member_index"] == 2
+
+    events = store.list_events(job_id)
+    failed = [e["data"] for e in events if e["type"] == "step.failed"]
+    skipped = [e["data"] for e in events if e["type"] == "step.skipped"]
+    assert len(failed) == 1
+    assert len(skipped) == 1
+    assert skipped[0]["reason"] == "skipped by fail_fast policy"
+
+
+def test_each_member_writes_its_own_step_log(store, providers, settings, monkeypatch):
+    """A member's inner steps log into the *member's* step log (keyed by the
+    outer step id). SponsorBlock's SBCUT parsing reads exactly that file, so
+    two members in flight must never share one — prove the files are distinct
+    and uncontaminated while both members really overlap."""
+    barrier = threading.Barrier(2)
+    logs: dict[str, object] = {}
+    original = FakeProvider.execute
+
+    def log_a_marker(self, step, ctx):
+        uri = step.params.get("uri", "")
+        barrier.wait(timeout=_BARRIER_TIMEOUT)
+        with open(ctx.stdout_log, "a", encoding="utf-8") as handle:
+            handle.write(f"MARKER {uri}\n")
+        logs[uri] = ctx.stdout_log
+        return original(self, step, ctx)
+
+    monkeypatch.setattr(FakeProvider, "execute", log_a_marker)
+
+    job_id = _pipeline(store, providers, settings)(_each_item_video_payload())
+
+    assert store.get_job(job_id)["status"] == "succeeded"
+    assert len(set(logs.values())) == 2, "two members shared a step log"
+    for uri, path in logs.items():
+        content = path.read_text(encoding="utf-8")
+        assert content == f"MARKER {uri}\n", f"foreign lines in {path.name}"
+
+
+def test_plain_jobs_and_lone_members_never_touch_the_pool(
+    store, providers, settings, monkeypatch
+):
+    """An ordinary single-video job and a one-member collection must not pay
+    for the pool: the executor runs them inline on the worker's own thread
+    (the pool's threads are recognizable by their job-id prefix)."""
+    thread_names: list[str] = []
+    original_execute = FakeProvider.execute
+    original_analyze = FakeProvider.analyze
+
+    def record_thread(self, step, ctx):
+        thread_names.append(threading.current_thread().name)
+        return original_execute(self, step, ctx)
+
+    def analyze_with_one_member(self, source, ctx):
+        analysis = original_analyze(self, source, ctx)
+        if analysis.resource.resource_type == "collection":
+            del analysis.entries[1:]
+        return analysis
+
+    monkeypatch.setattr(FakeProvider, "execute", record_thread)
+    monkeypatch.setattr(FakeProvider, "analyze", analyze_with_one_member)
+
+    run = _pipeline(store, providers, settings)
+    plain = run(minimal_payload())  # a plain single-source audio job
+    lone = run(_each_item_video_payload())  # a collection of exactly one
+    assert store.get_job(plain)["status"] == "succeeded"
+    assert store.get_job(lone)["status"] == "succeeded"
+    assert thread_names, "nothing executed?"
+    assert all("member" not in name for name in thread_names), thread_names

--- a/docs/architecture-decisions/0019-collections-orchestrate-single-resource-pipelines.md
+++ b/docs/architecture-decisions/0019-collections-orchestrate-single-resource-pipelines.md
@@ -82,9 +82,11 @@ of (request, analysis). That holds per member.
   guessing codecs, languages or capabilities. Correctness must not depend on
   how long a playlist is.
 - **No eager whole-collection probing.** Analysis happens as each member enters
-  execution, bounded to 1–2 concurrent members initially. The analysis cache
-  (`CONTENT_ANALYSIS_TTL_HOURS`) applies per resource, so re-submitting a
-  playlist re-reads rather than re-probes.
+  execution, bounded by `CONTENT_COLLECTION_MEMBER_CONCURRENCY` (default 2,
+  1 = strictly sequential) — a politeness bound toward the provider, since two
+  concurrent members are two concurrent downloads from the same host. The
+  analysis cache (`CONTENT_ANALYSIS_TTL_HOURS`) applies per resource, so
+  re-submitting a playlist re-reads rather than re-probes.
 - **No duplicated planner logic.** A member is planned by `build_plan`, the
   same function a single video uses. If per-item planning ever needs a rule the
   single-resource path lacks, that rule belongs in the single-resource path.
@@ -136,8 +138,16 @@ To build — small, and none of it plans:
    analyze → `build_plan` → the ordinary step loop for that member's plan, and
    binds the resulting artifacts to the collection's output id (the existing
    `per_item` binding already expresses "one output, N artifacts").
-3. **Bounded concurrency** over members, conservative to start (1–2), so a long
-   playlist does not become a probe storm against the provider.
+3. **Bounded concurrency** over members
+   (`CONTENT_COLLECTION_MEMBER_CONCURRENCY`, default 2), so a long playlist
+   does not become a probe storm against the provider. The executor dispatches
+   a run of member steps — independent by construction — to a small thread
+   pool and nothing else: what a member *is* never changes, only when it
+   starts. Under `fail_fast`, a failing required member stops members that
+   have not started; members already in flight run to completion, because a
+   valid artifact is never thrown away mid-download. Cancellation reaches
+   in-flight members through the same `cancel_check` every step already
+   honors.
 
 One question the implementation must settle rather than assume: **member
 numbering**. Today `item_label` (`001-first`) is a planner-invented parameter.

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -115,6 +115,7 @@ console are not listed there because they always run.
 | `COMPOSE_PROFILES` | `hometube,studio` | Which download UIs start (`hometube`, `studio`, or both); the engine and the console always run |
 | `CONTENT_PORT` / `HOMETUBE_PORT` / `STUDIO_PORT` / `CONSOLE_PORT` | 8010 / 8501 / 8502 / 8503 | Host ports |
 | `CONTENT_MAX_CONCURRENT_JOBS` | 2 | Worker concurrency |
+| `CONTENT_COLLECTION_MEMBER_CONCURRENCY` | 2 | Playlist members downloading at once — a politeness bound toward the provider, not a throughput dial; 1 = strictly sequential |
 | `CONTENT_STEP_TIMEOUT_SECONDS` | 3600 | Per-step timeout |
 | **🌐 Network & access** | | |
 | `CONTENT_ALLOW_PRIVATE_NETWORKS` | false | SSRF guard (URLs pointing at private IPs) |


### PR DESCRIPTION
ADR 0019 planned "bounded to 1-2 concurrent members initially" and shipped strictly sequential; the prerequisite that made concurrency unsafe — the shared member workdir — was fixed and tested some time ago. This turns the plan on.

The executor now splits the ordered plan into dispatch groups: a run of consecutive collection.member steps — independent by construction, no member depends on another — goes to a small thread pool bounded by CONTENT_COLLECTION_MEMBER_CONCURRENCY (default 2, 1 = the sequential executor, unchanged); every other step keeps the strictly sequential loop. Orchestration stays orchestration (INV-018): the pool changes when a member starts, never what a member is. The state the steps share — status map, produced counters, materials, the fail-fast flag — moves into a _RunState whose every mutation holds one lock, held for dict work only; the store was already safe across threads (WAL, one short-lived connection per call, BEGIN IMMEDIATE around the event sequence), and member artifact names embed the member ordinal, so files cannot collide.

The bound is documented as a politeness limit toward the provider, not a throughput feature: two concurrent members are two concurrent downloads from the same host. Decided fail_fast semantics under concurrency: a failing required member stops members that have not started; members already in flight run to completion — a valid artifact is never thrown away mid-download. Cancellation reaches in-flight members through the same cancel_check every step honors.

Seven new tests pin the guarantees, with a barrier both members must reach in flight so a silently-sequential executor breaks the test rather than passing it: real overlap + isolated workdirs, limit 1 = disjoint intervals, per-step progress attribution, prompt cancellation, the fail_fast decision (3 members: one fails, the running one finishes, the queued one never starts), one step log per member (what SBCUT parsing reads), and plain jobs never touching the pool. Verified the barrier test fails under a forced limit of 1.

Live validation against a real playlist (Blender HQ, 3 members — a saturated pool with a queued member exercises the same shape as the prompt's 6 at less bandwidth), audio each_item, sequential vs concurrent engines: members 1+2 start the same second and member 3 takes the freed slot, and the two runs' artifacts are identical in name, size, sha256, member index, member URI and delivered path.