### PR TITLE
MCP: bring an artifact to the caller's machine

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -11,6 +11,19 @@ business logic**.
 any MCP client → content-mcp (this) → content_sdk → your Content engine (/api/v1)
 ```
 
+## Where downloaded files land
+
+`download_artifact` writes to the machine running this server — the counterpart
+to delivery, which writes to the engine's library. One variable bounds it:
+
+| Variable | Default | Role |
+| --- | --- | --- |
+| `CONTENT_MCP_DOWNLOAD_DIR` | `~/Downloads/Content` | The only directory this server may write to. Relative destinations resolve inside it; anything pointing outside is refused, not clamped |
+
+The refusal is deliberate. An MCP server writes to a real filesystem on an
+agent's say-so, so widening that is the operator's decision, taken once, rather
+than something a prompt can talk it into.
+
 ## Install
 
 The server is an ordinary Python application — nothing to clone:

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -24,6 +24,15 @@ INSTRUCTIONS = (
     "copied into the server's media library and each artifact reports its "
     "delivered_path there. An output spec may carry delivery "
     '{"mode": "inherit|deliver|none", "folder": …, "filename": …} to steer this. '
+    "Do steer it: get_config lists the library's existing folders, so choose "
+    "one that fits what the user asked for (or ask them which) rather than "
+    "letting everything pile up in the library root, and tell them the "
+    "delivered_path in your answer — 'saved to Tech/…' is the useful reply, an "
+    "artifact id is not. "
+    "Note that the engine's library lives on the *engine's* machine. When the "
+    "user wants the file on the machine you are running on — often the case "
+    "when the engine is a homelab or NAS — use download_artifact, which is the "
+    "only way bytes reach this side. "
     "A source whose resource_type is 'collection' (a playlist) is a special "
     "case worth knowing: its capabilities describe the collection itself, so "
     "media outputs read as unavailable there. To produce something for every "
@@ -85,6 +94,20 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         """Artifact metadata; small text artifacts are inlined, larger/binary
         ones return a download reference (never raw bytes over MCP)."""
         return service.get_artifact(client, artifact_id)
+
+    @server.tool()
+    def download_artifact(
+        artifact_id: str, destination: str | None = None
+    ) -> dict[str, Any]:
+        """Save an artifact onto the machine running this MCP server.
+
+        Use this when the user wants the file *here* rather than only in the
+        engine's library — typically when the engine runs on another machine.
+        `destination` is optional: omitted, the artifact keeps its own name in
+        the server's download directory (CONTENT_MCP_DOWNLOAD_DIR, default
+        ~/Downloads/Content). A path outside that directory is refused.
+        """
+        return service.download_artifact(client, artifact_id, destination)
 
     @server.tool()
     def get_config() -> dict[str, Any]:

--- a/apps/mcp/content_mcp/service.py
+++ b/apps/mcp/content_mcp/service.py
@@ -8,6 +8,8 @@ merely exposes them as MCP tools/resources.
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 
 from content_sdk import ContentClient, outputs
@@ -247,3 +249,63 @@ def job_resource(client: ContentClient, job_id: str) -> dict[str, Any]:
 
 def artifact_resource(client: ContentClient, artifact_id: str) -> dict[str, Any]:
     return client.get_artifact(artifact_id).model_dump()
+
+
+# --- bringing a file to the caller's machine ----------------------------------
+
+DOWNLOAD_DIR_ENV = "CONTENT_MCP_DOWNLOAD_DIR"
+DEFAULT_DOWNLOAD_DIR = "~/Downloads/Content"
+
+
+def download_root() -> Path:
+    """Where this MCP server is allowed to write, expanded and absolute."""
+    raw = os.getenv(DOWNLOAD_DIR_ENV, "").strip() or DEFAULT_DOWNLOAD_DIR
+    return Path(raw).expanduser().resolve()
+
+
+def _resolve_destination(root: Path, destination: str | None, filename: str) -> Path:
+    """A path inside *root*, or a refusal.
+
+    The MCP server writes to the user's own filesystem on an agent's say-so, so
+    the destination is confined to one directory the operator chose. Relative
+    paths resolve inside it; anything that escapes — an absolute path elsewhere,
+    a `..` climb, a symlink out — is refused rather than clamped, because
+    silently rewriting where a file went is worse than not writing it.
+    """
+    candidate = Path(destination).expanduser() if destination else root / filename
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    if candidate.is_dir():
+        candidate = candidate / filename
+    resolved = (candidate.parent.resolve() / candidate.name).absolute()
+    if resolved != root and root not in resolved.parents:
+        raise ValueError(
+            f"destination is outside {DOWNLOAD_DIR_ENV} ({root}). Pass a path "
+            f"inside it, or set {DOWNLOAD_DIR_ENV} to widen what this server "
+            "may write to."
+        )
+    return resolved
+
+
+def download_artifact(
+    client: ContentClient, artifact_id: str, destination: str | None = None
+) -> dict[str, Any]:
+    """Copy an artifact from the engine onto the machine running this server."""
+    artifact = client.get_artifact(artifact_id)
+    # The engine sanitizes names, but this writes to a real filesystem on an
+    # agent's request — take the basename regardless of what came back.
+    filename = Path(artifact.display_filename or artifact.filename).name
+    root = download_root()
+    root.mkdir(parents=True, exist_ok=True)
+    target = _resolve_destination(root, destination, filename)
+    written = client.download_artifact(artifact_id, target)
+    return {
+        "path": str(written),
+        "filename": written.name,
+        "size_bytes": artifact.size_bytes,
+        "media_type": artifact.media_type,
+        "note": (
+            "Saved on the machine running this MCP server. The engine's own "
+            "copy in its library (delivered_path) is unaffected."
+        ),
+    }

--- a/apps/mcp/tests/test_download_artifact.py
+++ b/apps/mcp/tests/test_download_artifact.py
@@ -1,0 +1,120 @@
+"""Bringing an artifact to the machine running the MCP server.
+
+Delivery puts a copy in the *engine's* library; this puts one on the *caller's*
+disk, which for a homelab engine was otherwise an scp. That makes the MCP server
+write to a real filesystem on an agent's say-so, so most of what is pinned here
+is the boundary: everything lands inside CONTENT_MCP_DOWNLOAD_DIR, and anything
+aimed outside it is refused rather than quietly moved back inside.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from content_mcp import service
+from content_sdk import ContentClient
+from content_sdk.errors import NotFound
+
+ARTIFACT = {
+    "id": "art_1",
+    "job_id": "job_1",
+    "artifact_request_id": "a",
+    "type": "audio",
+    "filename": "a.opus",
+    "display_filename": "My Talk - audio.opus",
+    "delivered_path": "Tech/My Talk - audio.opus",
+    "media_type": "audio/opus",
+    "size_bytes": 11,
+    "created_at": "t",
+}
+PAYLOAD = b"hello audio"
+
+
+def _client(payload: bytes = PAYLOAD, status: int = 200) -> ContentClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/content"):
+            return httpx.Response(status, content=payload)
+        return httpx.Response(200, json=ARTIFACT)
+
+    return ContentClient(
+        "http://testserver",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+@pytest.fixture
+def root(tmp_path, monkeypatch):
+    """A download directory of our own, so no test writes to ~/Downloads."""
+    target = tmp_path / "downloads"
+    monkeypatch.setenv(service.DOWNLOAD_DIR_ENV, str(target))
+    return target
+
+
+# --- the ordinary path ----------------------------------------------------------
+
+
+def test_no_destination_uses_the_artifacts_own_name(root):
+    result = service.download_artifact(_client(), "art_1")
+    written = root / "My Talk - audio.opus"
+    assert written.read_bytes() == PAYLOAD
+    assert result["path"] == str(written)
+    assert result["size_bytes"] == 11
+
+
+def test_a_relative_destination_resolves_inside_the_root(root):
+    result = service.download_artifact(_client(), "art_1", "talks/keep.opus")
+    assert (root / "talks" / "keep.opus").read_bytes() == PAYLOAD
+    assert result["filename"] == "keep.opus"
+
+
+def test_an_existing_directory_keeps_the_artifact_name(root):
+    (root / "talks").mkdir(parents=True)
+    service.download_artifact(_client(), "art_1", "talks")
+    assert (root / "talks" / "My Talk - audio.opus").read_bytes() == PAYLOAD
+
+
+def test_the_answer_says_where_the_file_is_and_what_it_did_not_touch(root):
+    result = service.download_artifact(_client(), "art_1")
+    # An agent reports this to a human, so it must be unambiguous about which
+    # of the two copies — engine library vs local disk — was just written.
+    assert "MCP server" in result["note"]
+    assert result["media_type"] == "audio/opus"
+
+
+# --- the boundary ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "destination",
+    ["/etc/passwd", "../escaped.opus", "talks/../../escaped.opus", "~/escaped.opus"],
+)
+def test_a_destination_outside_the_root_is_refused(root, destination):
+    with pytest.raises(ValueError, match="outside"):
+        service.download_artifact(_client(), "art_1", destination)
+
+
+def test_a_refusal_writes_nothing_at_all(root, tmp_path):
+    with pytest.raises(ValueError):
+        service.download_artifact(_client(), "art_1", str(tmp_path / "elsewhere.opus"))
+    assert not (tmp_path / "elsewhere.opus").exists()
+    assert list(root.rglob("*")) == [] or all(p.is_dir() for p in root.rglob("*"))
+
+
+def test_the_refusal_names_the_variable_that_would_widen_it(root):
+    with pytest.raises(ValueError, match=service.DOWNLOAD_DIR_ENV):
+        service.download_artifact(_client(), "art_1", "/tmp/x.opus")
+
+
+# --- failure leaves no debris ---------------------------------------------------
+
+
+def test_an_http_failure_leaves_no_partial_file(root):
+    with pytest.raises(NotFound):
+        service.download_artifact(_client(status=404), "art_1")
+    assert list(root.rglob("*.part")) == []
+    assert not (root / "My Talk - audio.opus").exists()
+
+
+def test_the_default_root_is_under_the_users_downloads(monkeypatch):
+    monkeypatch.delenv(service.DOWNLOAD_DIR_ENV, raising=False)
+    assert service.download_root().parts[-2:] == ("Downloads", "Content")

--- a/packages/python-sdk/content_sdk/_transport.py
+++ b/packages/python-sdk/content_sdk/_transport.py
@@ -13,6 +13,7 @@ import asyncio
 import os
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
 
@@ -44,6 +45,15 @@ def _raise_for(resp: httpx.Response) -> None:
     except ValueError:
         body = resp.text
     raise error_for(resp.status_code, body)
+
+
+def _raise_for_stream(resp: httpx.Response) -> None:
+    """`_raise_for` for a streamed response: the body must be read first, since
+    a streaming response has none until asked, and an error body is small."""
+    if resp.is_success:
+        return
+    resp.read()
+    _raise_for(resp)
 
 
 def _attempts(method: str, retry: RetryConfig, idempotent: bool) -> int:
@@ -108,6 +118,38 @@ class SyncTransport:
 
     def content(self, path: str) -> bytes:
         return self.request("GET", path).content
+
+    def stream_to(self, path: str, destination: Path) -> int:
+        """Stream a response body into *destination*, returning bytes written.
+
+        Deliberately not `content()` + `write_bytes()`: artifacts are media
+        files, and holding a multi-gigabyte video in memory to copy it to disk
+        is the kind of thing that works until someone downloads a real film.
+
+        Written to a sibling `.part` and renamed on completion, so an
+        interrupted transfer never leaves a truncated file wearing the real
+        name. No retry: replaying a partial stream needs range requests, and
+        silently resuming into a half-written file would be worse than failing.
+        """
+        url = _api_url(self.base_url, path)
+        partial = destination.with_name(destination.name + ".part")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        written = 0
+        try:
+            with self._client.stream("GET", url) as response:
+                _raise_for_stream(response)
+                with partial.open("wb") as handle:
+                    for chunk in response.iter_bytes(chunk_size=1024 * 256):
+                        handle.write(chunk)
+                        written += len(chunk)
+        except httpx.TransportError as exc:
+            partial.unlink(missing_ok=True)
+            raise TransportError(str(exc)) from exc
+        except BaseException:
+            partial.unlink(missing_ok=True)
+            raise
+        os.replace(partial, destination)
+        return written
 
 
 class AsyncTransport:

--- a/packages/python-sdk/content_sdk/client.py
+++ b/packages/python-sdk/content_sdk/client.py
@@ -7,6 +7,7 @@ to typed exceptions. `analyze/get_capabilities/generate` accept **either** an
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, Self
 
 from ._transport import DEFAULT_TIMEOUT, RetryConfig, SyncTransport, resolve_base_url
@@ -191,3 +192,21 @@ class ContentClient:
 
     def artifact_bytes(self, artifact_id: str) -> bytes:
         return self._t.content(f"/artifacts/{artifact_id}/content")
+
+    def download_artifact(self, artifact_id: str, destination: Path | str) -> Path:
+        """Save an artifact to a local file, streaming it.
+
+        ``destination`` may be a directory — the artifact's display name is
+        used inside it — or an explicit file path. Returns the path written.
+
+        This is the counterpart to delivery: delivery puts a copy in the
+        *engine's* library, this puts one on the *caller's* machine, which for
+        a remote engine is otherwise a manual scp.
+        """
+        target = Path(destination)
+        if target.is_dir():
+            artifact = self.get_artifact(artifact_id)
+            name = artifact.display_filename or artifact.filename
+            target = target / Path(name).name
+        self._t.stream_to(f"/artifacts/{artifact_id}/content", target)
+        return target


### PR DESCRIPTION
An MCP session against a homelab engine produced the audio and then needed scp to actually get it. Half of that turned out not to be a missing feature: the engine already delivers by default and already exposes its library folders, so files were landing in the library root simply because nothing asked for a folder, and the answer never said where they went. The instructions now tell an agent to choose a folder from get_config and to report delivered_path rather than an artifact id.

The other half was genuinely missing, and no amount of delivery tuning reaches it: delivery is server-side by definition, and the person is on another machine. The MCP server is not — it runs locally, which is what makes this the one place that can close the gap.

So: download_artifact(artifact_id, destination). The SDK gains a streaming download (chunked to disk, written to a .part and renamed on completion, so an interrupted transfer never leaves a truncated file wearing the real name) rather than reusing artifact_bytes, which holds the whole response in memory — fine for a subtitle file, not for a film.

The boundary got most of the attention, because this writes to a real filesystem on an agent's say-so. Everything lands inside CONTENT_MCP_DOWNLOAD_DIR (default ~/Downloads/Content); a destination outside it is refused rather than quietly moved back inside, and the refusal names the variable that would widen it — an operator's decision taken once, not something a prompt can argue its way past. Twelve tests cover the ordinary paths, four escape attempts, and that a failure leaves no debris. Verified end to end against the running engine.