### PR TITLE
Align the HomeTube story, and two fixes the MCP verification found

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 [Quick start](#quick-start) ·
 [HomeTube](#hometube--youtube-focused) ·
+[Coming from HomeTube?](#coming-from-standalone-hometube) ·
 [All the clients](#the-clients) ·
 [Connect an agent](#mcp-server--for-agents-and-ides) ·
 [Read the docs](docs/README.md)
@@ -50,14 +51,17 @@ pick what you want out of it, and watch the files land in your library.
 see media/README.md. -->
 
 > [!NOTE]
-> **A proven workflow, now growing into a platform.** The standalone HomeTube
-> container has passed **300,000 package downloads on GitHub Container
-> Registry** and remains maintained during the transition. Content carries
-> that familiar workflow forward and is designed to become its successor.
+> **A proven workflow, now growing into a platform.** The standalone
+> [HomeTube](https://github.com/EgalitarianMonkey/hometube) container has passed
+> **300,000 package downloads on GitHub Container Registry**. It keeps running
+> and stays maintained — nothing breaks, and there is no deadline. Content is
+> where that work continues, and where its users are invited to move at their
+> own pace.
 >
-> The standalone HomeTube project remains separate; it has not been retrofitted
-> to run on Content. This repository contains a new HomeTube UI built on the
-> Content engine.
+> The two are separate projects: standalone HomeTube has not been retrofitted to
+> run on Content. The **HomeTube app in this repository is a new UI on the
+> Content engine**, carrying the same workflow forward.
+> [Coming from standalone HomeTube? ↓](#coming-from-standalone-hometube)
 
 ## Quick start
 
@@ -195,6 +199,37 @@ variable and works the language rules through a concrete example — a Japanese
 talk, a French speaker, and exactly what ends up pre-checked. The
 [full variable table](docs/operations/deployment.md#configuration-a-root-env-not-versioned)
 lists everything the engine accepts.
+
+### Coming from standalone HomeTube?
+
+[HomeTube](https://github.com/EgalitarianMonkey/hometube) — the standalone
+Streamlit app — **keeps running and stays maintained**. Nothing breaks, and there
+is no deadline. Content is where the work continues, so this is a move you make
+when you are ready, not one you are forced into.
+
+**What comes across.** The workflow you know: paste a URL, choose quality, codec,
+container, audio languages and subtitles; remove or mark sponsored segments with
+SponsorBlock; cut clips; unlock restricted videos with a server-side cookie file;
+embed subtitles, chapters, thumbnails and metadata; and deliver readable file
+names into a library watched by Plex, Jellyfin, or Emby. Playlists come across
+too — each entry is analyzed and planned on its own, named per item, and
+delivered as its own artifact.
+
+**What is new.** The same source can also produce a transcript, a summary, a
+translation, generated thumbnails, metadata, Markdown, or PDF. And the engine is
+no longer reachable only from a web form: Studio, the Chromium extension, an MCP
+agent, the CLI, the SDK, and plain HTTP all ask for the same things.
+
+**What has not made the trip yet.** HomeTube's playlist **synchronization** — the
+plan/apply diff that keeps a local folder in step with a playlist over time
+(rename detection, archiving or deleting removed videos, relocation after a
+naming or location change) — does not exist here. Content downloads a playlist;
+it does not yet re-sync one. It is [roadmapped as part of
+M2](docs/roadmap/roadmap.md). If playlist sync is your main use, keep standalone
+HomeTube for that job.
+
+**One practical note.** Both HomeTube apps default to port **8501**. Change one of
+them in your `.env` if you want to run the two side by side.
 
 ### Content Studio — the whole contract, in a form
 

--- a/apps/backend/content/providers/documents.py
+++ b/apps/backend/content/providers/documents.py
@@ -208,8 +208,14 @@ class DocumentProvider:
         if inline is not None:
             body, title = inline, ""
         else:
+            # engine_roots, like every other call: an uploaded file lives in
+            # the engine's own uploads directory, which is deliberately not an
+            # allowed *input* root (ADR 0020). Omitting it here let an upload
+            # analyse fine and then fail at execution.
             path = check_path_allowed(
-                step.params.get("path", ""), ctx.settings.allowed_input_roots
+                step.params.get("path", ""),
+                ctx.settings.allowed_input_roots,
+                engine_roots=(uploads_root(ctx.settings),),
             )
             body = path.read_text(encoding="utf-8", errors="replace")
             title = (

--- a/apps/backend/content/providers/ffmpeg.py
+++ b/apps/backend/content/providers/ffmpeg.py
@@ -405,8 +405,14 @@ class FfmpegProvider:
 
     def _input_path(self, step: PlanStep, ctx: ExecutionContext) -> Path:
         try:
+            # engine_roots as everywhere else: an uploaded file sits in the
+            # engine's uploads directory, which is not an allowed *input* root
+            # (ADR 0020). Without it, every upload analysed fine and then died
+            # in its first step.
             return check_path_allowed(
-                step.params["path"], ctx.settings.allowed_input_roots
+                step.params["path"],
+                ctx.settings.allowed_input_roots,
+                engine_roots=(uploads_root(ctx.settings),),
             )
         except AnalysisError as exc:
             # The file changed/vanished between planning and execution.

--- a/apps/backend/tests/test_uploads.py
+++ b/apps/backend/tests/test_uploads.py
@@ -119,6 +119,47 @@ def test_an_uploaded_file_can_be_submitted_as_a_job(client):
     assert response.status_code == 201, response.text
 
 
+def test_an_uploaded_file_runs_to_a_finished_artifact(client, settings):
+    """The test above stops at 201 — the job is *accepted*. That gap hid a real
+    defect: an upload analysed fine and then failed in its first step with
+    "File sources are disabled", because the execution-time path check forgot
+    the engine's own uploads directory while the analysis-time one remembered
+    it. An upload that cannot be executed is not an upload feature.
+
+    Found by driving the published MCP server against a real engine, which is
+    the only place a job actually runs to completion from an uploaded file.
+    """
+    from content.execution.executor import JobExecutor
+    from content.persistence.store import Store
+
+    upload_id = _upload(client)
+    response = client.post(
+        "/api/v1/jobs",
+        json={
+            "schema_version": "1.0",
+            "sources": [{"id": "s", "type": "upload", "upload_id": upload_id}],
+            "outputs": [{"id": "m", "type": "markdown"}],
+        },
+    )
+    assert response.status_code == 201, response.text
+    job_id = response.json()["job_id"]
+
+    store = Store(settings.db_path)
+    executor = JobExecutor(
+        store=store,
+        settings=settings,
+        providers=ProviderRegistry(
+            [DocumentProvider()], processors=[TranscriptProcessor()]
+        ),
+    )
+    executor.execute(store.claim_next_queued())
+
+    job = store.get_job(job_id)
+    assert job["status"] == "succeeded", job.get("error")
+    artifacts = store.list_artifacts(job_id)
+    assert artifacts, "the upload produced no artifact"
+
+
 def test_capabilities_answer_for_an_upload(client):
     upload_id = _upload(client)
     response = client.post(

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -119,9 +119,39 @@ Build the distributions with `make wheels` (they land in `dist/`).
 - The full journey — MCP service → SDK → real FastAPI engine → executor →
   delivery library, including `delivery` intent and `mode: "none"`:
   **verified in-process** (`tests/test_end_to_end.py`, in `make validate`).
-- The installed wheel driven over stdio by an MCP client session against a
-  running engine: **verified** at packaging time (see the repository's
-  release notes); re-run it after any transport change.
+- The **published wheel** (`uv tool install content-mcp`, 0.6.0 from PyPI)
+  driven **over stdio by an MCP client session** against a **running 0.6.0
+  engine**: **verified 2026-08-21**. What was actually run, end to end:
+
+  | Path | Result |
+  | --- | --- |
+  | stdio handshake, `tools/list`, `resources/templates/list` | 9 tools, the three `content://` templates |
+  | `get_config` → `analyze_source` → `list_capabilities` → `generate` → `get_job` → `get_artifact` | a web page produced a delivered `markdown` artifact, inlined as text |
+  | A real YouTube download | `audio` (opus), 7.5 MB, delivered under its display name |
+  | A binary artifact through `get_artifact` | **not** inlined — reference only, as designed |
+  | `download_artifact` into `CONTENT_MCP_DOWNLOAD_DIR` | file written on this side |
+  | `download_artifact` to a path **outside** it | refused, with the variable named |
+  | A playlist with `scope: "each_item"` | 19 entries → 19 artifacts, numbered `001 - …`, one delivered file each |
+  | Engine unreachable / wrong port | actionable message (see below) — this is what the run *fixed* |
+
+  Re-run it after any transport change; the in-process suites above never reach
+  a closed socket, which is exactly how the error-message defect survived.
+
+## When something goes wrong
+
+Every tool translates the SDK's exceptions into something an agent can act on,
+because the alternative is what this server used to say when the engine was not
+running: `[Errno 61] Connection refused`. It names neither what failed nor what
+to do, and it is the **first** thing a new user meets — the engine listens on
+`8010` on the host and `8000` only inside its container, so pointing at the
+wrong one is the ordinary mistake.
+
+| Situation | What the caller is told |
+| --- | --- |
+| The engine is not reachable | Which URL was tried, that `docker compose up -d` starts it, that `CONTENT_API_URL` moves it, and the 8010/8000 distinction |
+| An analysis has expired | That analyses are kept for a limited time, and to call `analyze_source` again |
+| The engine refused the request | The stable error codes (`output_type_not_supported`, …) and the body |
+| An output spec is malformed | Caught *before* the round trip, with an example of a correct one |
 
 ## Design
 

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -7,9 +7,18 @@ no business logic here. stdio transport (HTTP can come later).
 
 from __future__ import annotations
 
+from functools import wraps
 from typing import Any
 
 from content_sdk import ContentClient
+from content_sdk.errors import (
+    APIError,
+    ContentError,
+    Gone,
+    NotFound,
+    TransportError,
+    ValidationError,
+)
 from mcp.server import MCPServer
 
 from . import service
@@ -47,12 +56,76 @@ INSTRUCTIONS = (
 )
 
 
+def _actionable(exc: ContentError, base_url: str) -> str:
+    """Turn an SDK exception into a sentence the agent — and the person reading
+    over its shoulder — can act on.
+
+    Without this, an engine that is not running answers `[Errno 61] Connection
+    refused`. That is the first thing a new user meets when they get the port
+    wrong (the container listens on 8000 inside and 8010 on the host), and it
+    names neither what failed nor what to do. The failure is not the engine's;
+    the unusable message is ours.
+    """
+    if isinstance(exc, TransportError):
+        return (
+            f"The Content engine is not reachable at {base_url}. Start it "
+            "(`docker compose up -d`), or set CONTENT_API_URL to where it runs "
+            "— note the engine listens on port 8010 on the host, 8000 only "
+            f"inside its container. ({exc})"
+        )
+    if isinstance(exc, Gone):
+        return (
+            f"That reference has expired ({base_url}): analyses are kept for a "
+            "limited time. Call analyze_source again to get a fresh "
+            f"analysis_id. ({'; '.join(exc.codes) or exc})"
+        )
+    if isinstance(exc, NotFound):
+        return f"The engine has no such record. ({'; '.join(exc.codes) or exc})"
+    if isinstance(exc, ValidationError):
+        codes = "; ".join(exc.codes)
+        return (
+            "The engine refused this request"
+            + (f" ({codes})" if codes else "")
+            + f". {exc.body}"
+        )
+    if isinstance(exc, APIError):
+        return f"The engine answered HTTP {exc.status}. {exc.body}"
+    return str(exc)
+
+
+def _friendly(fn, client: ContentClient):
+    """Wrap one tool so SDK errors surface as guidance rather than errno."""
+
+    @wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return fn(*args, **kwargs)
+        except ContentError as exc:
+            raise RuntimeError(_actionable(exc, client.base_url)) from exc
+
+    return wrapper
+
+
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
     server = MCPServer(name="content", version="0.6.0", instructions=INSTRUCTIONS)
 
+    def tool():
+        """`server.tool()`, with SDK errors translated on the way out."""
+
+        def register(fn):
+            return server.tool()(_friendly(fn, client))
+
+        return register
+
+    def resource(uri: str):
+        def register(fn):
+            return server.resource(uri)(_friendly(fn, client))
+
+        return register
+
     # --- tools (intention-level) ---------------------------------------------
-    @server.tool()
+    @tool()
     def analyze_source(url: str, credential: str | None = None) -> dict[str, Any]:
         """Analyze a source and report what can be produced from it.
 
@@ -63,12 +136,12 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         """
         return service.analyze_source(client, url, credential=credential)
 
-    @server.tool()
+    @tool()
     def list_capabilities(analysis_id: str) -> dict[str, Any]:
         """Resolve the public capabilities available for an analyzed source."""
         return service.list_capabilities(client, analysis_id)
 
-    @server.tool()
+    @tool()
     def generate(analysis_id: str, outputs: list[Any]) -> dict[str, Any]:
         """Start a job producing the requested outputs from an analyzed source.
 
@@ -85,28 +158,28 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         """
         return service.generate(client, analysis_id, outputs)
 
-    @server.tool()
+    @tool()
     def get_job(job_id: str) -> dict[str, Any]:
         """Get a job's status and, once terminal, its produced artifacts."""
         return service.get_job(client, job_id)
 
-    @server.tool()
+    @tool()
     def cancel_job(job_id: str) -> dict[str, Any]:
         """Request cooperative cancellation of a running job."""
         return service.cancel_job(client, job_id)
 
-    @server.tool()
+    @tool()
     def list_jobs(limit: int = 20) -> dict[str, Any]:
         """List recent jobs (most recent first)."""
         return service.list_jobs(client, limit)
 
-    @server.tool()
+    @tool()
     def get_artifact(artifact_id: str) -> dict[str, Any]:
         """Artifact metadata; small text artifacts are inlined, larger/binary
         ones return a download reference (never raw bytes over MCP)."""
         return service.get_artifact(client, artifact_id)
 
-    @server.tool()
+    @tool()
     def download_artifact(
         artifact_id: str, destination: str | None = None
     ) -> dict[str, Any]:
@@ -120,7 +193,7 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         """
         return service.download_artifact(client, artifact_id, destination)
 
-    @server.tool()
+    @tool()
     def get_config() -> dict[str, Any]:
         """Server-side context for building requests: credential ids for
         authenticated sources, whether delivery-by-default is on, and the
@@ -128,15 +201,15 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         return service.get_config(client)
 
     # --- resources (read-only, single content:// namespace) -------------------
-    @server.resource("content://analyses/{analysis_id}")
+    @resource("content://analyses/{analysis_id}")
     def analysis_resource(analysis_id: str) -> dict[str, Any]:
         return service.analysis_resource(client, analysis_id)
 
-    @server.resource("content://jobs/{job_id}")
+    @resource("content://jobs/{job_id}")
     def job_resource(job_id: str) -> dict[str, Any]:
         return service.job_resource(client, job_id)
 
-    @server.resource("content://artifacts/{artifact_id}")
+    @resource("content://artifacts/{artifact_id}")
     def artifact_resource(artifact_id: str) -> dict[str, Any]:
         return service.artifact_resource(client, artifact_id)
 

--- a/apps/mcp/tests/test_error_messages.py
+++ b/apps/mcp/tests/test_error_messages.py
@@ -1,0 +1,130 @@
+"""An error an agent cannot act on is a bug, whatever the status code says.
+
+Every tool delegates to the SDK, and the SDK's exceptions carry HTTP truth
+rather than guidance. Unwrapped, an engine that is not running answered
+`[Errno 61] Connection refused` — which names neither what failed nor what to
+do, and is the *first* thing a new user meets when they point the server at
+the wrong port (the engine listens on 8010 on the host, 8000 only inside its
+container).
+
+Found by driving the published wheel over stdio against a real engine, which
+is the only place this shows up: in-process tests never reach a closed socket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from content_mcp.server import build_server
+from content_sdk import ContentClient
+
+
+def _client(handler) -> ContentClient:
+    return ContentClient(
+        "http://engine.example:8010",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+def _call(server, name: str, arguments: dict | None = None):
+    return asyncio.run(server.call_tool(name, arguments or {}))
+
+
+def _message(excinfo) -> str:
+    return str(excinfo.value)
+
+
+def test_an_unreachable_engine_names_the_url_and_the_remedy():
+    def refuse(request):
+        raise httpx.ConnectError("[Errno 61] Connection refused")
+
+    server = build_server(_client(refuse))
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "get_config")
+
+    message = _message(excinfo)
+    assert "http://engine.example:8010" in message, "say which engine"
+    assert "docker compose up -d" in message, "say how to start it"
+    assert "CONTENT_API_URL" in message, "say how to point elsewhere"
+    assert "8010" in message and "8000" in message, "name the port confusion"
+
+
+def test_an_expired_analysis_says_to_analyze_again():
+    def gone(request):
+        return httpx.Response(410, json={"code": "analysis_expired"})
+
+    server = build_server(_client(gone))
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "list_capabilities", {"analysis_id": "ana_stale"})
+
+    message = _message(excinfo)
+    assert "expired" in message.lower()
+    assert "analyze_source" in message, "name the tool that fixes it"
+
+
+def test_a_refused_request_carries_the_stable_codes():
+    def refused(request):
+        return httpx.Response(
+            422,
+            json={
+                "detail": {
+                    "valid": False,
+                    "errors": [{"code": "output_type_not_supported", "message": "no"}],
+                }
+            },
+        )
+
+    server = build_server(_client(refused))
+    with pytest.raises(Exception) as excinfo:
+        _call(
+            server,
+            "generate",
+            {"analysis_id": "ana_1", "outputs": [{"id": "x", "type": "ocr"}]},
+        )
+
+    assert "output_type_not_supported" in _message(excinfo)
+
+
+def test_a_malformed_output_is_caught_before_the_engine_is_called():
+    """The server already answers this one well, and it must keep doing so:
+    the guidance is worth more than the round trip it saves."""
+
+    def unreachable(request):  # pragma: no cover - must never be reached
+        raise AssertionError("the engine should not have been called")
+
+    server = build_server(_client(unreachable))
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "generate", {"analysis_id": "ana_1", "outputs": [{"id": "x"}]})
+
+    message = _message(excinfo)
+    assert "no 'type'" in message and "Example" in message
+
+
+def test_a_missing_record_is_not_dressed_up_as_something_else():
+    def missing(request):
+        return httpx.Response(404, json={"detail": "job not found"})
+
+    server = build_server(_client(missing))
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "get_job", {"job_id": "job_nope"})
+
+    assert "no such record" in _message(excinfo).lower()
+
+
+def test_wrapping_did_not_break_the_tool_surface():
+    """The wrapper must stay invisible to the protocol: same tools, same
+    schemas. `functools.wraps` is what keeps the generated input schema
+    correct, and a decorator that quietly emptied it would disable every
+    argument."""
+
+    def ok(request):
+        return httpx.Response(200, json={})
+
+    server = build_server(_client(ok))
+    tools = {t.name: t for t in asyncio.run(server.list_tools())}
+    assert "analyze_source" in tools
+    schema = tools["analyze_source"].input_schema
+    assert schema["required"] == ["url"]
+    assert set(schema["properties"]) == {"url", "credential"}

--- a/docs/operations/mcp-registry.md
+++ b/docs/operations/mcp-registry.md
@@ -77,10 +77,9 @@ It is skipped for TestPyPI and for a recovery publish that did not include the
 MCP package, because announcing a version whose wheel did not go out would be a
 lie the registry then serves.
 
-**By hand**, if that job has to be replayed — note that the CLI's `login github`
-is a **browser action for the maintainer**, since the `gh` CLI on the
-development machine is authenticated as the wrong account and must never be
-used for writes (AGENTS.md):
+**By hand**, if that job has to be replayed — `mcp-publisher login github`
+opens a browser, so it is the maintainer who completes it. Make sure the
+identity it proves is `YannOrieult` (AGENTS.md, *Public identity*):
 
 ```bash
 brew install mcp-publisher     # or the tarball from the registry's releases
@@ -114,4 +113,5 @@ likely return:
 | Glama | crawls repositories; check whether it already knows us |
 | Smithery | submission |
 
-Each of those is a **write action performed as `YannOrieult`**, in a browser.
+Each of those is a **write action performed as `YannOrieult`** — check
+`gh api user --jq .login` first if any of them is done from the CLI.

--- a/docs/product/scope.md
+++ b/docs/product/scope.md
@@ -11,7 +11,8 @@ explicit decision (PO/architect). The non-goals are as firm as the goals.
 - **Outputs**: `video`, `audio`, `metadata`, `thumbnail`, `subtitles`,
   `transcript` (from existing subtitles), `summary` (local Ollama LLM, from
   subtitles, audio or extracted text), `document_text`, `markdown`.
-- **Cardinality scope**: `single` only.
+- **Cardinality scope**: `single` and `each_item` (a collection fans out into
+  one member step per entry, inside one job — ADR 0019).
 - **Execution**: asynchronous jobs, a SQLite queue, an embedded worker, ordered
   events + SSE, cancellation, retry (a new, linked job), content-based reuse
   (`reuse_existing`), resumption of `running` jobs on restart.
@@ -24,8 +25,11 @@ explicit decision (PO/architect). The non-goals are as firm as the goals.
   fallback, SponsorBlock, cut (trim), chapters/description/comments,
   multi-audio, merged/separate mode, `delivery` (folder + naming), a web UI
   dedicated to URLs.
-- **Collections**: `each_item` scope (playlists → one job per item), playlist
-  sync.
+- **Collections**: playlist **synchronization** — keeping a local folder in step
+  with a playlist over time (plan/apply diff, rename detection, archiving or
+  deleting removed entries, relocation). The `each_item` fan-out it was listed
+  beside is **executed** (above); sync is the half still targeted, and the one
+  standalone-HomeTube feature with no equivalent here.
 - **Hardening**: observability, effective retention, intra-job resumption,
   finishing the contract's honesty.
 

--- a/docs/releases/v0.6.1.md
+++ b/docs/releases/v0.6.1.md
@@ -1,0 +1,60 @@
+Two fixes found the only way they could be found: by installing the published
+MCP server from PyPI and driving it against a running engine, the way a new
+user does.
+
+## Uploading a file and generating from it was broken
+
+An uploaded file analysed cleanly, resolved cleanly, planned cleanly — and
+then died in its first step:
+
+```text
+File sources are disabled: no allowed input roots are configured
+```
+
+`check_path_allowed` distinguishes two kinds of root on purpose (ADR 0020):
+operator policy (`CONTENT_ALLOWED_INPUT_ROOTS`, which governs `file` sources)
+and engine-owned roots (the uploads directory, which is deliberately *not* an
+allowed input root). Both analysis-time callers passed the engine root. Both
+execution-time callers did not.
+
+Every route was affected: Studio's **From this device**, the SDK's
+`upload_file()`, and the MCP server's local-file support — the one that lets an
+agent on a laptop drive an engine on a NAS. On the Docker deployment the same
+defect wore a different message (`outside the allowed input roots`, since
+`/input` is configured and the uploads directory is not under it).
+
+The test suite could not see it. `test_an_uploaded_file_can_be_submitted_as_a_job`
+asserted a 201 and stopped there, so no test ever *ran* a job from an upload.
+One does now, and reverting either half of the fix turns it red.
+
+## The MCP server says what to do when it cannot reach the engine
+
+With the engine down, or `CONTENT_API_URL` pointing at `:8000` instead of
+`:8010`, every tool answered `[Errno 61] Connection refused`. That names
+neither what failed nor what to do, and it is the first thing a newcomer meets
+— the engine listens on 8010 on the host and 8000 only inside its container.
+
+Tools now translate the SDK's exceptions: an unreachable engine names the URL
+it tried, the command that starts it, the variable that moves it and the
+8010/8000 distinction; an expired analysis says to call `analyze_source` again;
+a refused request carries the stable error codes.
+
+## What else that verification confirmed
+
+The published wheel, driven over stdio against a real 0.6.0 engine: the full
+journey on a web page, a real YouTube audio download delivered under its display
+name, a binary artifact correctly *not* inlined, `download_artifact` refusing a
+destination outside `CONTENT_MCP_DOWNLOAD_DIR`, and a playlist producing 19
+numbered artifacts from 19 entries. `apps/mcp/README.md` records what was run.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+uv tool install --reinstall content-mcp
+```
+
+No migration. If you tried uploading a file on 0.6.0 and the job failed, it
+will work now.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.0...v0.6.1

--- a/docs/roadmap/roadmap.md
+++ b/docs/roadmap/roadmap.md
@@ -64,16 +64,33 @@ Counts are a snapshot of a real `make validate` run, not a target.
   selector is enough.
 - **Complexity:** medium-high. **Order:** the first product value.
 
-## M2 — Collections / playlists · **considered**
+## M2 — Collections / playlists · **in progress**
 
 - **Goal:** process a whole playlist.
-- **Capabilities:** `each_item` scope (fan-out: one job/artifact per item),
-  playlist sync (archive/rename detection).
-- **Prerequisites:** M1; probably R4 (a first-class plan in the DB) decided
-  first.
-- **Risks:** the first non-`single` scope; an explosion of child jobs.
-- **Exit criteria:** a playlist URL produces N traceable results.
-- **Complexity:** high.
+- **Capabilities:**
+  - `each_item` fan-out — **delivered**. A `collection` resource expands into
+    one member step per entry inside a single job (ADR 0019): each member is
+    analyzed and planned by the canonical single-resource pipeline, named per
+    item and delivered as its own artifact, with member concurrency bounded by
+    `CONTENT_COLLECTION_MEMBER_CONCURRENCY` (default 2). ADR 0022 completed it
+    for per-member audio.
+  - Playlist **synchronization** — **still open**. Keeping a local folder in
+    step with a playlist over time: the plan/apply diff, rename detection,
+    archiving or deleting removed entries, relocation after a naming or
+    location change. Nothing of it exists (`playlist_sync.py` is "Discard (V1)"
+    in [../hometube-reuse-audit.md](../hometube-reuse-audit.md), and
+    `reuse_existing` is still inert). It is the one standalone-HomeTube feature
+    with no equivalent here, and the README says so to anyone arriving from it.
+- **Prerequisites:** M1. R4 (a first-class plan in the DB) turned out not to
+  block the fan-out.
+- **Risks:** the first non-`single` scope — met. "An explosion of child jobs"
+  did not happen and cannot: ADR 0019 expands members into steps of one job
+  rather than into jobs.
+- **Exit criteria:**
+  - fan-out — **met**: a playlist URL produces N traceable results in one job.
+  - sync — a local folder still matches a playlist that has changed since it was
+    first downloaded, without re-downloading what is already there.
+- **Complexity:** high (the remainder is the sync half).
 
 ## M3 — Production hardening · **considered** (may precede M2 if usage demands it)
 


### PR DESCRIPTION
Four commits. The first two were planned; the last two came out of actually
driving the published MCP server against a running engine, which no test does.

### 1. `26b11ae` — both repositories tell the same story about HomeTube

The note here said the standalone container "remains maintained during the
transition", which reads as a countdown nobody announced. HomeTube keeps
running, stays maintained, and moving is an invitation. A
"Coming from standalone HomeTube?" section answers the three questions an
arrival actually has — what comes across, what is new, and what is missing.

The third is the blunt one: **playlist synchronization does not exist here**.
Re-verified against the code rather than carried over: the `each_item` fan-out
is real, and sync is absent everywhere. Which exposed a roadmap saying
otherwise — M2 was still `considered` with half of it shipped, and `scope.md`
carried the same contradiction twice. Both corrected, since the README now
points at them.

### 2. `44480cc` — the MCP server says what to do when it cannot reach the engine

With the engine down, or `CONTENT_API_URL` on `:8000` instead of `:8010`, every
tool answered `[Errno 61] Connection refused`. It names neither what failed nor
what to do, and it is the first thing a newcomer meets. Tools now translate the
SDK's exceptions; `functools.wraps` keeps the generated input schemas intact,
and a test asserts that.

### 3. `95791c1` — an uploaded file survives past the analysis ⚠️

**The one that matters.** Uploading a file and generating from it was broken end
to end. `check_path_allowed` takes operator roots and engine roots apart on
purpose (ADR 0020); both analysis-time callers passed the engine root, both
execution-time callers did not. So an upload analysed cleanly, planned cleanly,
then died in its first step — on every route: Studio's "From this device", the
SDK's `upload_file()`, and the MCP server's local-file support.

The suite could not see it: `test_an_uploaded_file_can_be_submitted_as_a_job`
asserts a 201 and stops, so no test ever *ran* a job from an upload. One does
now, and reverting either half of the fix turns it red.

### 4. `c049a4f` — release notes for 0.6.1

## Verification

`make validate` green. Beyond it, the published 0.6.0 wheel was installed from
PyPI and driven over stdio against a real engine: full journey on a web page, a
real 7.5 MB YouTube audio download, a binary artifact correctly not inlined,
`download_artifact` refusing a destination outside its directory, and a playlist
producing 19 numbered artifacts from 19 entries. `apps/mcp/README.md` records
what was run, replacing "verified at packaging time".