### PR TITLE
YouTube's quiet refusal is a cookie problem, not a format one

### DIFF
--- a/apps/backend/content/providers/ytdlp.py
+++ b/apps/backend/content/providers/ytdlp.py
@@ -247,6 +247,14 @@ def classify_failure(stderr_text: str) -> str:
     # made this branch unreachable for the one message that produces it.
     if "bot" in lowered and ("sign in" in lowered or "confirm" in lowered):
         return "bot_detection"
+    # The quiet face of the same thing. When YouTube distrusts an anonymous
+    # client it does not always say so: it answers with a *degraded* format
+    # list holding nothing but storyboards, and yt-dlp then reports "Requested
+    # format is not available" — sending the user to look for the wrong
+    # problem. Observed on a video that downloads fine with cookies seconds
+    # later, so the answer is the cookie remedy, not a format one.
+    if "only images are available" in lowered:
+        return "bot_detection"
     if any(pattern in lowered for pattern in _AUTH_PATTERNS):
         return "authentication_required"
     if "requested format is not available" in lowered:

--- a/apps/backend/tests/test_auth.py
+++ b/apps/backend/tests/test_auth.py
@@ -339,3 +339,31 @@ def test_cookie_state_is_the_three_situations(
         for k, v in configured.items()
     }
     assert cookie_state(credential, with_credentials(settings, **creds)) == expected
+
+
+def test_a_degraded_format_list_is_read_as_bot_detection():
+    """YouTube does not always say "sign in to confirm you're not a bot". For
+    an anonymous client it distrusts, it can answer with a format list holding
+    only storyboards, and yt-dlp reports a *format* problem:
+
+        WARNING: Only images are available for download.
+        ERROR: Requested format is not available.
+
+    Taken at face value that sends the user hunting for the wrong thing. The
+    same URL, with cookies, downloads seconds later — so the honest answer is
+    the cookie remedy. Observed while verifying the MCP server on 2026-08-21.
+    """
+    stderr = (
+        "WARNING: Only images are available for download. "
+        "use --list-formats to see them\n"
+        "ERROR: [youtube] aqz-KE-bpKQ: Requested format is not available."
+    )
+    assert classify_failure(stderr) == "bot_detection"
+
+
+def test_a_genuine_format_refusal_is_still_a_format_problem(settings):
+    """The narrow marker matters: asking for a format a source really does not
+    have must not be dressed up as an authentication problem."""
+    stderr = "ERROR: Requested format is not available. Use --list-formats"
+    assert classify_failure(stderr) == "format_unavailable"
+    assert failure_remedy("format_unavailable", None, settings) == ""


### PR DESCRIPTION
Found while verifying the MCP server against a real engine, and nearly filed as a regression.

An audio download that had worked an hour earlier failed with `format_unavailable`, and the step log said:

```
WARNING: Only images are available for download
ERROR: Requested format is not available
```

The same URL **with cookies** downloaded seconds later — byte for byte the same 7.5 MB file. The format was available; YouTube had stopped serving it to an anonymous client it had come to distrust, answering with a degraded list holding only storyboards.

Classified as `format_unavailable`, that sends the user to read about codecs and containers when what they need is a `cookies.txt`. It is now read as `bot_detection`, which already carries the three-situation cookie remedy.

The marker is narrow — `only images are available` — so a genuine format refusal stays one. A test pins both directions; the useful half is the half that does *not* fire.

This is the first thing a new user will hit: downloading a YouTube video without cookies is the obvious first try.