### PR TITLE
Version 0.6.2

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.1"
+    org.opencontainers.image.version="0.6.2"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.1"
+version = "0.6.2"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.1"
+version = "0.6.2"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.1"]
+dependencies = ["content-sdk==0.6.2"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.1", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.2", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.1"
+version = "0.6.2"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.1", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.2", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.1"
+version = "0.6.2"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.2.md
+++ b/docs/releases/v0.6.2.md
@@ -1,0 +1,38 @@
+One fix, for the first thing a new user is likely to hit.
+
+## A YouTube refusal that reads as a format problem is a cookie problem
+
+An anonymous download can fail like this:
+
+```text
+WARNING: Only images are available for download
+ERROR: Requested format is not available
+```
+
+The format is available. YouTube had stopped serving it to an anonymous client
+it had come to distrust, and answered with a degraded list holding nothing but
+storyboards. Verified while testing 0.6.1: the same URL, with a cookies file,
+downloaded seconds later — byte for byte the same file.
+
+Classified as `format_unavailable`, that sends you to read about codecs and
+containers when what you need is a `cookies.txt`. It is now classified as
+`bot_detection`, which carries the remedy added in 0.6.1: it says whether no
+credential is configured, whether one is declared but its file is missing (so
+the download ran anonymously), or whether cookies were used and still refused.
+
+The marker is narrow — `only images are available` — so asking for a format a
+source genuinely lacks is still reported as a format problem. Both directions
+are pinned by tests.
+
+If you download from YouTube without cookies, this is worth reading:
+[config/README.md](https://github.com/LatentNoise/content/blob/main/config/README.md).
+From a clone, `make cookies FILE=~/Downloads/cookies.txt` installs an export.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+uv tool install --reinstall --refresh content-mcp
+```
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.1...v0.6.2

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.1"
+version = "0.6.2"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump + notes for 0.6.2, shipping the classification fix merged in #32: a YouTube refusal that reads as a format problem is a cookie problem.

Released on its own rather than held back, because downloading a YouTube video without cookies is the first thing anyone tries, and `format_unavailable` sent them to read about codecs.