### PR TITLE
Content reads a PDF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:  ## List the available targets
 	  | awk -F ':.*## ' '{printf "  \033[1m%-18s\033[0m %s\n", $$1, $$2}'
 
 install: hooks  ## Create the venv and install the engine + SDK + CLI + MCP + shared client
-	cd apps/backend && uv venv .venv && uv pip install -e ".[test,dev,pdf]" --python .venv/bin/python
+	cd apps/backend && uv venv .venv && uv pip install -e ".[test,dev,pdf,read]" --python .venv/bin/python
 	uv pip install -e packages/python-sdk --python apps/backend/.venv/bin/python
 	uv pip install -e apps/cli -e apps/mcp --python apps/backend/.venv/bin/python
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ and failing halfway through a job.
 | **Chapters** | Chapters declared by the source, or chapters derived from a transcript through an LLM |
 | **Thumbnail and keyframes** | Published artwork or frames extracted from video |
 | **Metadata** | Normalized, provider-independent resource information |
-| **Markdown and plain text** | Readable web pages, text files, Markdown files, and inline text |
+| **Markdown and plain text** | Readable web pages, text and Markdown files, **PDFs** (their text layer), and inline text |
 | **PDF** | Readable sources or outputs such as summaries, transcripts, and translations |
 
 Media acquisition works with YouTube and the

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -71,10 +71,13 @@ COPY apps/backend/pyproject.toml ./
 
 # --only-binary forces prebuilt wheels (pydantic-core on musl) so the build
 # fails fast instead of compiling Rust.
-# reportlab is a pure-Python wheel, so it installs on musl without a toolchain;
-# it is small enough to ship by default, unlike the speech-to-text extra below.
+# reportlab (writing PDFs) and pypdf (reading them) are both pure-Python
+# wheels, so they install on musl without a toolchain; both are small enough to
+# ship by default, unlike the speech-to-text extra below. Shipping the reader
+# by default is what makes "summarize this PDF" work on a stock install rather
+# than only for whoever thought to add an extra.
 RUN pip install --no-cache-dir --only-binary=:all: --no-compile \
-    fastapi uvicorn pydantic "reportlab>=4.0"
+    fastapi uvicorn pydantic "reportlab>=4.0" "pypdf>=5.1"
 
 # Optional speech-to-text runner (audio.transcribe → transcript/summary from
 # audio). Off by default — the wheels are heavy (ctranslate2). Enable with:

--- a/apps/backend/content/providers/documents.py
+++ b/apps/backend/content/providers/documents.py
@@ -43,9 +43,83 @@ MAX_BYTES = 10 * 1024 * 1024
 
 MARKDOWN_SUFFIXES = {".md", ".markdown"}
 TEXT_SUFFIXES = {".txt", ".text"}
+PDF_SUFFIXES = {".pdf"}
 READABLE_SUFFIXES = MARKDOWN_SUFFIXES | TEXT_SUFFIXES
 # Recognised, understood, and honestly refused until a real reader is warranted.
-DEFERRED_SUFFIXES = {".pdf", ".docx", ".epub", ".odt", ".rtf"}
+DEFERRED_SUFFIXES = {".docx", ".epub", ".odt", ".rtf"}
+
+
+def pdf_reader():
+    """``pypdf``'s PdfReader when it is installed, else ``None``.
+
+    An installation fact, resolved at call time rather than at import: the same
+    shape every optional runner in this engine uses (the Whisper runner, the
+    PDF renderer). Without it, ``.pdf`` keeps the refusal it always had — the
+    message already said "by this installation", which is now literally true
+    rather than a polite way of saying "never".
+    """
+    try:
+        from pypdf import PdfReader
+    except ImportError:  # pragma: no cover - exercised by the no-pypdf test
+        return None
+    return PdfReader
+
+
+def extract_pdf_text(path: Path) -> str:
+    """The text a PDF carries, page by page, joined by blank lines.
+
+    Text *layer* only. A scanned page holds an image of words and no words, so
+    it legitimately yields nothing — and that is reported as its own answer
+    rather than as an empty document, because "this PDF is a scan, you want
+    OCR" and "this PDF is empty" send the reader to different places.
+    """
+    reader = pdf_reader()
+    if reader is None:  # pragma: no cover - guarded by the caller
+        raise RuntimeError("pypdf is not installed")
+    try:
+        document = reader(str(path))
+        if getattr(document, "is_encrypted", False):
+            # An empty user password is common and decrypts silently; a real
+            # one cannot be guessed, and saying so beats returning no text.
+            try:
+                document.decrypt("")
+            except Exception as exc:
+                raise AnalysisError(
+                    ValidationIssue(
+                        code=codes.ANALYSIS_FAILED,
+                        message=(
+                            "This PDF is password-protected, so its text "
+                            "cannot be read."
+                        ),
+                        details={"provider": "document"},
+                    )
+                ) from exc
+        pages = [(page.extract_text() or "").strip() for page in document.pages]
+    except AnalysisError:
+        raise
+    except Exception as exc:
+        raise AnalysisError(
+            ValidationIssue(
+                code=codes.ANALYSIS_FAILED,
+                message=f"This PDF could not be read: {exc}.",
+                details={"provider": "document"},
+            )
+        ) from exc
+    body = "\n\n".join(page for page in pages if page)
+    if not body.strip():
+        raise AnalysisError(
+            ValidationIssue(
+                code=codes.SOURCE_TYPE_NOT_SUPPORTED,
+                message=(
+                    f"This PDF carries no extractable text across its "
+                    f"{len(pages)} page(s) — it is most likely a scan. Reading "
+                    "one needs OCR, which this engine does not implement."
+                ),
+                details={"provider": "document", "pages": len(pages)},
+            ),
+            terminal=True,
+        )
+    return body
 
 
 def _title_from(markdown: str, fallback: str) -> str:
@@ -79,7 +153,11 @@ class DocumentProvider:
             suffix = Path(source.path).suffix.lower()
             # Deferred formats are claimed on purpose: refusing them here with a
             # reason beats letting them fall through to "no provider at all".
-            return suffix in READABLE_SUFFIXES or suffix in DEFERRED_SUFFIXES
+            return (
+                suffix in READABLE_SUFFIXES
+                or suffix in PDF_SUFFIXES
+                or suffix in DEFERRED_SUFFIXES
+            )
         return False
 
     def resource_key(self, source: SourceDescriptor, ctx: AnalysisContext) -> str:
@@ -123,6 +201,19 @@ class DocumentProvider:
             engine_roots=(uploads_root(ctx.settings),),
         )
         suffix = path.suffix.lower()
+        if suffix in PDF_SUFFIXES and pdf_reader() is None:
+            raise AnalysisError(
+                ValidationIssue(
+                    code=codes.SOURCE_TYPE_NOT_SUPPORTED,
+                    message=(
+                        "PDF reading needs the 'pypdf' package, which is not "
+                        "installed here. Install content-backend[read], or use "
+                        "the published image, which ships it."
+                    ),
+                    details={"provider": self.name, "suffix": suffix},
+                ),
+                terminal=True,
+            )
         if suffix in DEFERRED_SUFFIXES:
             # Terminal: without it the chain fell through to ffmpeg, which
             # answered "ffprobe could not analyze the file" — technically true,
@@ -159,6 +250,8 @@ class DocumentProvider:
                         details={"provider": self.name, "limit_bytes": MAX_BYTES},
                     )
                 )
+            if path.suffix.lower() in PDF_SUFFIXES:
+                return extract_pdf_text(path)
             return path.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
             raise AnalysisError(
@@ -217,7 +310,20 @@ class DocumentProvider:
                 ctx.settings.allowed_input_roots,
                 engine_roots=(uploads_root(ctx.settings),),
             )
-            body = path.read_text(encoding="utf-8", errors="replace")
+            # Through `_read`, not `read_text`: a PDF has to go through the
+            # extractor here exactly as it does at analysis time. Reading it
+            # directly returned the file's own bytes as "text" — the analysis
+            # said the document was readable and the artifact then contained
+            # `%PDF-1.3 ... /BaseFont /Helvetica`, which is worse than a
+            # refusal because nothing failed.
+            try:
+                body = self._read(path)
+            except AnalysisError as exc:
+                # Same translation ffmpeg's `_input_path` does: a reader problem
+                # met during execution is a step failure, and it keeps the
+                # reason (a scan needing OCR, a password, a file that changed
+                # under us) instead of becoming a bare traceback.
+                raise StepExecutionError(exc.issue.code, exc.issue.message) from exc
             title = (
                 _title_from(body, path.stem)
                 if path.suffix.lower() in MARKDOWN_SUFFIXES

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -26,6 +26,13 @@ dev = [
 stt = [
     "faster-whisper>=1.0",
 ]
+# Optional document *reader* (a `.pdf` file source): installing it lets the
+# document provider extract a PDF's text layer. pypdf is BSD-3-Clause and a
+# pure-Python wheel — the same two properties that decided reportlab below, so
+# it installs on musl without a toolchain and attaches no licence obligation.
+read = [
+    "pypdf>=5.1",
+]
 # Optional document renderer (pdf.render): installing it activates the
 # `pdf` output type. reportlab is BSD-licensed — deliberately not the lighter
 # fpdf2, whose LGPL terms would attach obligations to a commercial licence.

--- a/apps/backend/tests/test_pdf_sources.py
+++ b/apps/backend/tests/test_pdf_sources.py
@@ -1,0 +1,223 @@
+"""Reading a `.pdf` file source (its text layer).
+
+`.pdf` was recognised and refused: "recognised but not yet readable by this
+installation". That was honest and it was also the single most common thing
+people try first — "summarize this PDF" is the sentence an agent hears more
+than any other. pypdf is BSD-3-Clause and a pure-Python wheel, which are the
+two properties that let it ship by default.
+
+What is read is the **text layer**. A scanned page holds an image of words and
+no words, and gets its own answer rather than being reported as an empty
+document: "you want OCR" and "this file is empty" send a reader to different
+places.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from content.domain.analysis import AnalysisError
+from content.domain.request import FileSource
+from content.providers.base import AnalysisContext
+from content.providers.documents import (
+    DocumentProvider,
+    extract_pdf_text,
+    pdf_reader,
+)
+
+pytest.importorskip("reportlab", reason="the test needs to author a PDF")
+
+TEXT = "Revenue grew 12 percent this quarter. Costs were flat."
+
+
+def _pdf(path, lines=(TEXT,), pages=1):
+    from reportlab.pdfgen import canvas
+
+    pdf = canvas.Canvas(str(path))
+    for _ in range(pages):
+        for index, line in enumerate(lines):
+            pdf.drawString(72, 720 - index * 18, line)
+        pdf.showPage()
+    pdf.save()
+    return path
+
+
+def _empty_pdf(path, pages=2):
+    """A page with no text at all — what a scan looks like to a text reader."""
+    from reportlab.pdfgen import canvas
+
+    pdf = canvas.Canvas(str(path))
+    for _ in range(pages):
+        pdf.showPage()
+    pdf.save()
+    return path
+
+
+@pytest.fixture
+def ctx(settings, tmp_path):
+    return AnalysisContext(settings=settings, workdir=tmp_path / "work")
+
+
+@pytest.fixture
+def allowing(settings, tmp_path):
+    from dataclasses import replace
+
+    return replace(settings, allowed_input_roots=(tmp_path,))
+
+
+# --- the extractor --------------------------------------------------------------
+
+
+def test_the_text_layer_comes_back(tmp_path):
+    assert "Revenue grew 12 percent" in extract_pdf_text(_pdf(tmp_path / "r.pdf"))
+
+
+def test_every_page_is_read(tmp_path):
+    body = extract_pdf_text(_pdf(tmp_path / "multi.pdf", pages=3))
+    assert body.count("Revenue grew") == 3
+
+
+def test_a_scan_is_not_reported_as_an_empty_document(tmp_path):
+    with pytest.raises(AnalysisError) as excinfo:
+        extract_pdf_text(_empty_pdf(tmp_path / "scan.pdf"))
+    issue = excinfo.value.issue
+    assert issue.code == "source_type_not_supported"
+    assert "scan" in issue.message.lower() and "ocr" in issue.message.lower()
+    assert issue.details.get("pages") == 2
+
+
+def test_a_file_that_is_not_a_pdf_fails_as_unreadable(tmp_path):
+    broken = tmp_path / "broken.pdf"
+    broken.write_bytes(b"not a pdf at all")
+    with pytest.raises(AnalysisError) as excinfo:
+        extract_pdf_text(broken)
+    assert "could not be read" in excinfo.value.issue.message
+
+
+# --- through the provider -------------------------------------------------------
+
+
+def test_a_pdf_source_analyses_like_any_document(allowing, tmp_path):
+    provider = DocumentProvider()
+    source = FileSource(id="s", type="file", path=str(_pdf(tmp_path / "r.pdf")))
+    assert provider.supports(source)
+
+    ctx = AnalysisContext(settings=allowing, workdir=tmp_path / "work")
+    analysis = provider.analyze(source, ctx)
+
+    assert analysis.text.has_text
+    assert analysis.text.word_count > 5
+    assert analysis.resource.resource_type == "document"
+
+
+def test_summary_and_markdown_become_producible_from_a_pdf(allowing, tmp_path):
+    """The point of the feature: what a caller can now ask for."""
+    from content.capabilities.facts import facts_from_analysis
+    from content.planning.feasibility import output_feasibility
+    from content.providers.base import ProviderRegistry
+
+    provider = DocumentProvider()
+    source = FileSource(id="s", type="file", path=str(_pdf(tmp_path / "r.pdf")))
+    ctx = AnalysisContext(settings=allowing, workdir=tmp_path / "work")
+    analysis = provider.analyze(source, ctx)
+
+    facts = facts_from_analysis(analysis)
+    assert facts.has_material("text")
+
+    registry = ProviderRegistry([provider])
+    assert output_feasibility("markdown", analysis, registry).status != "unavailable"
+
+
+def test_without_pypdf_the_refusal_says_what_to_install(
+    allowing, tmp_path, monkeypatch
+):
+    """The optional-runner shape every other capability uses: absent means a
+    clear refusal naming the remedy, never a crash."""
+    monkeypatch.setattr("content.providers.documents.pdf_reader", lambda: None)
+    provider = DocumentProvider()
+    source = FileSource(id="s", type="file", path=str(_pdf(tmp_path / "r.pdf")))
+    ctx = AnalysisContext(settings=allowing, workdir=tmp_path / "work")
+
+    with pytest.raises(AnalysisError) as excinfo:
+        provider.analyze(source, ctx)
+    message = excinfo.value.issue.message
+    assert "pypdf" in message and "content-backend[read]" in message
+
+
+def test_pypdf_is_installed_here():
+    """A guard on the environment itself: `make install` carries the extra, and
+    the published image ships it. If this fails, the feature silently degrades
+    to a refusal for everybody."""
+    assert pdf_reader() is not None
+
+
+def test_execution_extracts_the_text_rather_than_reading_the_bytes(allowing, tmp_path):
+    """The trap this exists for, found end to end and not by reading the code.
+
+    Analysis and execution read the file through different lines. Teaching the
+    analysis path about PDFs made a PDF *look* readable, and the artifact then
+    contained the file's own bytes:
+
+        # report
+        %PDF-1.3 … /BaseFont /Helvetica /Encoding /WinAnsiEncoding …
+
+    Nothing failed. The job succeeded, the agent summarised PostScript
+    operators, and the only symptom was nonsense — which is worse than a
+    refusal, because a refusal is actionable.
+    """
+    from content.domain.plan import PlanStep
+    from content.planning import transformations as T
+    from content.providers.base import ExecutionContext
+
+    source = _pdf(tmp_path / "r.pdf")
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    step = PlanStep(
+        id="extract",
+        operation=T.TEXT_EXTRACT,
+        provider="document",
+        params={"path": str(source), "format": "markdown"},
+    )
+    produced = DocumentProvider().execute(
+        step,
+        ExecutionContext(
+            settings=allowing,
+            workdir=workdir,
+            stdout_log=workdir / "out.log",
+            stderr_log=workdir / "err.log",
+            timeout_seconds=30,
+        ),
+    )
+
+    body = produced[0].path.read_text()
+    assert "Revenue grew 12 percent" in body
+    assert "%PDF" not in body and "BaseFont" not in body
+
+
+def test_a_scan_fails_the_step_with_its_reason(allowing, tmp_path):
+    """And the reader's refusal must survive the trip into execution as a step
+    failure carrying the reason, not as a traceback."""
+    from content.domain.plan import PlanStep
+    from content.planning import transformations as T
+    from content.providers.base import ExecutionContext, StepExecutionError
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    step = PlanStep(
+        id="extract",
+        operation=T.TEXT_EXTRACT,
+        provider="document",
+        params={"path": str(_empty_pdf(tmp_path / "scan.pdf")), "format": "markdown"},
+    )
+    with pytest.raises(StepExecutionError) as excinfo:
+        DocumentProvider().execute(
+            step,
+            ExecutionContext(
+                settings=allowing,
+                workdir=workdir,
+                stdout_log=workdir / "out.log",
+                stderr_log=workdir / "err.log",
+                timeout_seconds=30,
+            ),
+        )
+    assert "ocr" in str(excinfo.value).lower()

--- a/apps/backend/tests/test_text_sources.py
+++ b/apps/backend/tests/test_text_sources.py
@@ -50,6 +50,7 @@ def docs_root(tmp_path):
     (root / "note.md").write_text("# Release Notes\n\nThe engine got faster.\n")
     (root / "plain.txt").write_text("just some words in a file\n")
     (root / "paper.pdf").write_bytes(b"%PDF-1.4 not really a pdf")
+    (root / "thesis.docx").write_bytes(b"PK\x03\x04 not really a docx")
     (root / "clip.mp4").write_bytes(b"\x00\x00\x00\x18ftypmp42")
     return root
 
@@ -287,16 +288,29 @@ def test_an_inline_text_source_is_readable(ctx):
     assert analysis.text.word_count == 4
 
 
-def test_a_pdf_is_recognised_and_honestly_refused(docs_root, ctx):
+def test_a_deferred_format_is_recognised_and_honestly_refused(docs_root, ctx):
     """'Valid but not implemented' is a different answer from 'invalid'
-    (INV-014) — and a different answer from silently producing garbage."""
-    source = FileSource(id="d", type="file", path=str(docs_root / "paper.pdf"))
-    assert DocumentProvider().supports(source), "a PDF must be claimed, then refused"
+    (INV-014) — and a different answer from silently producing garbage.
+
+    This used to be the `.pdf` test. PDFs are read now, so the invariant moves
+    to the formats still deferred (`.docx`, `.epub`, `.odt`, `.rtf`): claimed
+    by the reader on purpose, then refused with a reason, terminally."""
+    source = FileSource(id="d", type="file", path=str(docs_root / "thesis.docx"))
+    assert DocumentProvider().supports(source), "claimed on purpose, then refused"
     with pytest.raises(AnalysisError) as exc:
         DocumentProvider().analyze(source, ctx)
     assert exc.value.issue.code == "source_type_not_supported"
-    assert ".pdf" in exc.value.issue.message
+    assert ".docx" in exc.value.issue.message
     assert exc.value.terminal, "a deliberate refusal must stop the fallback chain"
+
+
+def test_a_file_that_only_claims_to_be_a_pdf_fails_as_unreadable(docs_root, ctx):
+    """`paper.pdf` holds a header and nothing else. Now that PDFs are read, the
+    honest answer is that this one could not be, not that PDFs are unsupported."""
+    source = FileSource(id="d", type="file", path=str(docs_root / "paper.pdf"))
+    with pytest.raises(AnalysisError) as exc:
+        DocumentProvider().analyze(source, ctx)
+    assert "could not be read" in exc.value.issue.message
 
 
 def test_a_document_outside_the_allowed_roots_is_refused(ctx):
@@ -370,18 +384,19 @@ def test_capabilities_on_a_document_offer_text_and_refuse_media(
         assert caps[media]["reason"]["code"] == "missing_material"
 
 
-def test_the_pdf_refusal_survives_the_fallback_chain(doc_settings, docs_root):
-    """Regression (D-27): the provider-level PDF test passed while the *API*
+def test_a_deliberate_refusal_survives_the_fallback_chain(doc_settings, docs_root):
+    """Regression (D-27): the provider-level test passed while the *API*
     answered "ffprobe could not analyze the file". DocumentProvider's deliberate
     refusal was overwritten by the next candidate in the chain, so the honest
     answer never reached the caller. The provider list here is the one that
-    caused it — document, then ffmpeg."""
+    caused it — document, then ffmpeg. (Written for `.pdf`, which is read now;
+    `.docx` carries the same shape.)"""
     with _api(doc_settings, _text_providers()) as client:
         response = client.post(
             "/api/v1/capabilities",
             json={
                 "sources": [
-                    {"id": "a", "type": "file", "path": str(docs_root / "paper.pdf")}
+                    {"id": "a", "type": "file", "path": str(docs_root / "thesis.docx")}
                 ]
             },
         )

--- a/docs/product/scope.md
+++ b/docs/product/scope.md
@@ -6,8 +6,9 @@ explicit decision (PO/architect). The non-goals are as firm as the goals.
 ## In scope (today, executed)
 
 - **Sources**: `url` (media through yt-dlp, web pages through the reader),
-  `file` (media through ffmpeg, `.txt`/`.md` through the document reader, both
-  under allowed roots), `text` (inline).
+  `file` (media through ffmpeg, `.txt`/`.md`/`.pdf` through the document
+  reader — a PDF's text layer, not a scan, which would need OCR — all under
+  allowed roots), `text` (inline), `upload` (bytes a client sent, ADR 0020).
 - **Outputs**: `video`, `audio`, `metadata`, `thumbnail`, `subtitles`,
   `transcript` (from existing subtitles), `summary` (local Ollama LLM, from
   subtitles, audio or extracted text), `document_text`, `markdown`.
@@ -35,8 +36,8 @@ explicit decision (PO/architect). The non-goals are as firm as the goals.
 
 ## Considered later (hypotheses, not committed)
 
-- `upload` sources, PDF text extraction (recognised and refused today, since
-  doing it well needs a real dependency), connectors.
+- `.docx`/`.epub`/`.odt`/`.rtf` text extraction — recognised and refused today,
+  each needing its own reader. OCR for a scanned PDF, same reason. Connectors.
 - `keyframes`, `ocr`, `pdf`, `embeddings`, `semantic_index`, `archive`,
   `collection` outputs.
 - `each_source`, `all_sources`, `collection`, `group` scopes.


### PR DESCRIPTION
"Summarize this PDF from my laptop" is the sentence an agent hears more than any other, and it was the one thing the engine answered with a refusal: `.pdf` sat in `DEFERRED_SUFFIXES`, recognised and honestly turned away since *doing it well needs a real dependency*.

pypdf is that dependency, with the two properties that decided reportlab: **BSD-3-Clause**, and a **pure-Python wheel** that installs on musl with no toolchain. It ships in the image by default rather than behind an extra — a feature that works only for whoever thought to add `[read]` is not a feature you can tell people about.

What is read is the **text layer**. A scan holds an image of words and no words, so it gets its own answer (*"most likely a scan, reading one needs OCR"*) rather than being reported as an empty document. A password-protected file says so too, after trying the empty user password that usually works.

### Two traps, both found end to end

- **Analysis and execution read the file through different lines.** Teaching only the analysis path made a PDF *look* readable, and the artifact then contained `%PDF-1.3 … /BaseFont /Helvetica`. Nothing failed — the job succeeded and the agent summarised PostScript operators. Worse than a refusal, because a refusal is actionable.
- **The reader's refusals had to survive into execution**, translated to a step failure that keeps the reason, the way ffmpeg's `_input_path` already does.

### Tests

10 new, including both traps. The two tests that encoded the old behaviour now cover the formats still deferred (`.docx`, `.epub`, `.odt`, `.rtf`) — including D-27's fallback-chain regression. The invariant they protect is unchanged; only its example moved.

Verified end to end through the published MCP server: a real PDF on the laptop → uploaded → `Report.md` + `Report.pdf` delivered, with the extracted text readable by the agent.