### PR TITLE
Version 0.6.3

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.2"
+    org.opencontainers.image.version="0.6.3"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.2"
+version = "0.6.3"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.2"
+version = "0.6.3"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.2"]
+dependencies = ["content-sdk==0.6.3"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.2", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.3", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.2"
+version = "0.6.3"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.2", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.3", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.2"
+version = "0.6.3"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.3.md
+++ b/docs/releases/v0.6.3.md
@@ -1,0 +1,56 @@
+Content reads a PDF.
+
+## `summarize this PDF` now has an answer
+
+`.pdf` was recognised and honestly refused — *"recognised but not yet readable
+by this installation"* — because doing it well needs a real dependency. It is
+also the single most common thing anyone asks an agent to do with a file.
+
+The dependency is **pypdf**, chosen for the same two properties that decided
+reportlab: BSD-3-Clause, and a pure-Python wheel that installs on musl with no
+toolchain. It ships in the image by default, so this works on a stock install
+rather than for whoever thought to add an extra.
+
+```text
+"Summarize this PDF from my laptop and give me a Markdown file and a PDF."
+```
+
+That sentence now runs end to end through the MCP server: the file is uploaded
+from the machine running the agent, its text is extracted, and the outputs land
+in the engine's library.
+
+**It reads the text layer.** A scanned page holds an image of words and no
+words, so it gets its own answer — *"most likely a scan, reading one needs
+OCR"* — rather than being reported as an empty document, because that sends you
+somewhere useful. A password-protected file says so too, after trying the empty
+user password that usually works. `.docx`, `.epub`, `.odt` and `.rtf` are still
+recognised and refused, each needing its own reader.
+
+## Two defects this uncovered, worth knowing about
+
+Both were found by running the thing end to end, not by reading the code, and
+both are the same shape: **analysis and execution read a file through different
+lines**.
+
+The first is the one that shipped in this release's feature: teaching only the
+analysis path made a PDF *look* readable, and the artifact then contained
+`%PDF-1.3 … /BaseFont /Helvetica`. Nothing failed. The job succeeded and the
+agent summarised PostScript operators — worse than a refusal, because a refusal
+is actionable.
+
+The second was already there and is fixed in 0.6.1: an **uploaded** file
+analysed cleanly and then died in its first step, on every route that uploads
+(Studio's *From this device*, the SDK, the MCP server).
+
+If you are on 0.6.0 or earlier, this is the release to take.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+uv tool install --reinstall --refresh content-mcp
+```
+
+No migration. The image gains one pure-Python package.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.2...v0.6.3

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.2"
+version = "0.6.3"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump + notes for 0.6.3, shipping PDF reading (#34).

`summarize this PDF` is the most common thing anyone asks an agent to do with a file, and it was the one thing the engine refused. It now runs end to end through the MCP server: uploaded from the agent's machine, text extracted, outputs delivered.