### PR TITLE
The published image could not start, and had not since 0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,38 @@ jobs:
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
           echo "Publishing: $tags"
 
+      # The image is BUILT and RUN before anything is pushed, because a unit
+      # test cannot see this class of defect: it lives in the shipped artifact,
+      # not in the code. Between 0.5.0 and 0.6.3 the published backend image
+      # could not boot at all — FastAPI needs python-multipart to *register*
+      # the uploads route, the image did not have it, and `create_app()` raised
+      # on start. `make validate` stayed green throughout, because the dev
+      # environment installs the MCP server too, which happens to depend on
+      # python-multipart. Constructing the app inside the real image is the
+      # only check that would have caught it.
+      #
+      # amd64 only and `--load`: buildx cannot load a multi-arch manifest into
+      # the local daemon, and the missing-dependency class is architecture
+      # independent. The multi-arch build below reuses these layers from cache.
+      - name: Build the image for a boot check
+        if: matrix.image == 'content'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          load: true
+          tags: boot-check:${{ github.sha }}
+          provenance: false
+          sbom: false
+
+      - name: The app must actually build inside the image
+        if: matrix.image == 'content'
+        run: |
+          set -euo pipefail
+          docker run --rm boot-check:${{ github.sha }} \
+            python3 -c "from content.api.app import create_app; create_app(); print('app builds')"
+
       # Both architectures are really compiled — the arm64 half is the one that
       # breaks, since it needs musl wheels — and now they are pushed as a single
       # multi-arch manifest, so `docker pull` picks the right one by itself.

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -69,15 +69,33 @@ WORKDIR /app
 # Project metadata first for layer caching.
 COPY apps/backend/pyproject.toml ./
 
+# The runtime dependencies come from the pyproject — the file above — rather
+# than from a list repeated here.
+#
+# This used to be a hand-copied list, and that is exactly how the published
+# image shipped broken for four releases: 0.5.0 added the uploads route, whose
+# UploadFile parameter makes FastAPI require python-multipart at *registration*
+# time, the pyproject was not updated either, and the image's list certainly
+# was not. `create_app()` then raised on boot, so every tag from 0.5.0 to 0.6.3
+# had an API that could not start. Two lists could disagree; one cannot.
+#
+# `pdf` (reportlab, writing) and `read` (pypdf, reading) ship by default: both
+# are pure-Python wheels that install on musl with no toolchain, and a feature
+# that only works for whoever added an extra is not a feature you can announce.
+# `stt` stays optional below — those wheels are heavy.
+#
 # --only-binary forces prebuilt wheels (pydantic-core on musl) so the build
 # fails fast instead of compiling Rust.
-# reportlab (writing PDFs) and pypdf (reading them) are both pure-Python
-# wheels, so they install on musl without a toolchain; both are small enough to
-# ship by default, unlike the speech-to-text extra below. Shipping the reader
-# by default is what makes "summarize this PDF" work on a stock install rather
-# than only for whoever thought to add an extra.
-RUN pip install --no-cache-dir --only-binary=:all: --no-compile \
-    fastapi uvicorn pydantic "reportlab>=4.0" "pypdf>=5.1"
+RUN python3 -c "\
+import tomllib;\
+p = tomllib.load(open('pyproject.toml','rb'))['project'];\
+extras = p.get('optional-dependencies', {});\
+deps = p['dependencies'] + extras.get('pdf', []) + extras.get('read', []);\
+open('/tmp/requirements.txt','w').write(chr(10).join(deps))" \
+    && cat /tmp/requirements.txt \
+    && pip install --no-cache-dir --only-binary=:all: --no-compile \
+        -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
 
 # Optional speech-to-text runner (audio.transcribe → transcript/summary from
 # audio). Off by default — the wheels are heavy (ctranslate2). Enable with:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -10,6 +10,12 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.30",
     "pydantic>=2.7",
+    # Required by FastAPI to *register* a route taking an UploadFile — which
+    # `POST /api/v1/uploads` does (ADR 0020). Nothing in this codebase imports
+    # it, so no import-vs-declaration check can find it missing; FastAPI raises
+    # at route-registration time, meaning the app object cannot even be built.
+    # The bound is FastAPI's own (its `standard` extra pins the same).
+    "python-multipart>=0.0.18",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -1,0 +1,75 @@
+"""The runtime dependency set must describe what the engine actually needs.
+
+Between 0.5.0 and 0.6.3 every published backend image failed to boot. The
+uploads route (ADR 0020) takes an `UploadFile`, FastAPI requires
+`python-multipart` to *register* such a route, and the package was declared
+nowhere — so `create_app()` raised before the healthcheck could even run, and
+`docker compose up -d` said only "container content is unhealthy".
+
+Two properties made it survive four releases:
+
+* **Nothing imports it.** `grep -rn multipart apps/backend/content/` finds
+  nothing; FastAPI imports it internally and lazily. No import-vs-declaration
+  audit can see it.
+* **The development environment supplies it by accident.** `make install` also
+  installs `apps/mcp`, whose `mcp>=1.2` dependency pulls `python-multipart`.
+  So the CI suite was green while the shipped artifact was broken.
+
+The real guard is in `ci.yml`: the image is built and `create_app()` is called
+inside it before anything is pushed. This file guards the declaration itself,
+which is cheap and fails with a clearer message than a container that exits 1.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - the project requires 3.11+
+    import tomli as tomllib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+PYPROJECT = tomllib.loads((REPO / "apps/backend/pyproject.toml").read_text())
+DOCKERFILE = (REPO / "apps/backend/Dockerfile").read_text()
+
+
+def _names(requirements: list[str]) -> set[str]:
+    return {
+        re.split(r"[<>=!\[; ]", r, maxsplit=1)[0].strip().lower() for r in requirements
+    }
+
+
+def test_python_multipart_is_a_declared_runtime_dependency():
+    """The one FastAPI needs to build the app, not to serve a request."""
+    assert "python-multipart" in _names(PYPROJECT["project"]["dependencies"])
+
+
+def test_the_image_installs_from_the_pyproject_rather_than_a_copied_list():
+    """The duplication is what allowed the divergence: the code gained a
+    feature, the image's hand-written list did not. One source of truth means
+    the two cannot disagree again — so the Dockerfile must keep reading the
+    pyproject, and must not go back to naming packages by hand."""
+    assert "requirements.txt" in DOCKERFILE and "tomllib" in DOCKERFILE
+    # Shell continuations joined first, so one command reads as one line.
+    joined = DOCKERFILE.replace("\\\n", " ")
+    installs = [line for line in joined.splitlines() if "pip install" in line]
+    runtime = [i for i in installs if "faster-whisper" not in i]
+    for line in runtime:
+        assert "-r /tmp/requirements.txt" in line, (
+            "the runtime install must come from the pyproject, not a list "
+            f"repeated in the Dockerfile: {line!r}"
+        )
+
+
+def test_the_boot_check_runs_before_anything_is_pushed():
+    """A unit test cannot see a missing dependency that only the built image
+    lacks. The workflow must construct the app inside the image, and must do it
+    *before* the pushing step, or the guard proves nothing."""
+    workflow = (REPO / ".github/workflows/ci.yml").read_text()
+    assert "create_app()" in workflow, "no boot check in the image"
+    assert workflow.index("create_app()") < workflow.index("push: true"), (
+        "the boot check must run before the push, not after"
+    )


### PR DESCRIPTION
Every backend image from **0.5.0 to 0.6.3** exits 1 in a restart loop. `docker compose up -d` says only `container content is unhealthy` — doubly misleading, since the healthcheck never runs: the process dies first.

```
RuntimeError: Form data requires "python-multipart" to be installed.
```

0.5.0 added `POST /api/v1/uploads` (ADR 0020). Its `UploadFile` parameter makes FastAPI require python-multipart to **register** the route — not to serve it, to build the app object. `create_app()` raises, so there is no API at all.

### Three things were true at once; all three are fixed

1. **Declared nowhere** → added to the pyproject's runtime dependencies at FastAPI's own bound (`>=0.0.18`).
2. **The image repeated the list by hand** → it now derives the install from the pyproject it already copies for layer caching. One list instead of two.
3. **Nothing could have caught it** → Content never imports python-multipart (FastAPI does, internally and lazily), so no static audit sees it, and a unit test cannot: the defect lives only in the built artifact.

### Why CI stayed green

`make install` also installs `apps/mcp`, whose `mcp>=1.2` pulls `python-multipart`. The development environment supplied by accident exactly what the image lacked. Confirmed by installing only the declared extras into a clean venv: all 11 upload tests error out there.

### The guard

CI now builds the image and runs `create_app()` **inside it**, before the push step. amd64 with `--load` (buildx cannot load a multi-arch manifest, and this defect class is architecture independent); the multi-arch push reuses the layers.

### Verified against the artifacts, not the code

```
published 0.6.3   → RuntimeError: … python-multipart …
built from this   → app builds: OK   (python-multipart 0.0.32 present)
```