### PR TITLE
Version 0.6.4

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.3"
+    org.opencontainers.image.version="0.6.4"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.3"
+version = "0.6.4"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.3"
+version = "0.6.4"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.3"]
+dependencies = ["content-sdk==0.6.4"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.3", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.4", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.3"
+version = "0.6.4"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.3", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.4", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.3"
+version = "0.6.4"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.4.md
+++ b/docs/releases/v0.6.4.md
@@ -1,0 +1,67 @@
+**If you are running the Docker image, take this release.** Every published
+backend image from 0.5.0 to 0.6.3 could not start.
+
+## The API could not boot
+
+A stock `docker compose up -d` reported only:
+
+```text
+dependency failed to start: container content is unhealthy
+```
+
+which is doubly misleading — the healthcheck never ran, because the process
+died before it could. The real answer was in `docker logs`:
+
+```text
+RuntimeError: Form data requires "python-multipart" to be installed.
+```
+
+0.5.0 added `POST /api/v1/uploads` (ADR 0020). Its `UploadFile` parameter makes
+FastAPI require `python-multipart` to **register** the route — not to serve a
+request, to build the app object at all. So `create_app()` raised on start and
+there was no API, for four releases.
+
+Anyone who pulled 0.5.0 or later has an engine that cannot start. Upgrading is
+the whole fix:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+**The older tags are left as they are.** Republishing `0.5.0` with different
+contents would make a version number mean two things, which is worse than a tag
+that is honestly broken — and `0.6`, `0.6.4` and `latest` all now point at an
+image that boots. If you pinned an exact old tag, move to `0.6.4`.
+
+## Why four releases went out with it
+
+Three things were true at once, and all three are fixed rather than only the
+first.
+
+**It was declared nowhere.** Not in the pyproject, not in the image. It is now
+a runtime dependency at FastAPI's own bound.
+
+**The image repeated the dependency list by hand.** That is what let the two
+diverge: the code gained a feature, the pyproject did not, and the Dockerfile's
+list certainly did not. The image now derives its install from the pyproject it
+already copies, so there is one list instead of two.
+
+**Nothing could have caught it.** Content never imports `python-multipart` —
+FastAPI does, internally and lazily — so no import-vs-declaration audit sees it,
+and no unit test can: the defect exists only in the built artifact. Worse, the
+suite stayed green *because* `make install` also installs the MCP server, whose
+`mcp` dependency pulls `python-multipart` in. The development environment
+supplied by accident exactly what the image lacked.
+
+So the guard now sits where the defect lives: **CI builds the image and calls
+`create_app()` inside it before anything is pushed.** A release that cannot boot
+no longer reaches the registry.
+
+## Verifying it yourself
+
+```bash
+docker run --rm ghcr.io/latentnoise/content:0.6.4 \
+  python3 -c "from content.api.app import create_app; create_app(); print('ok')"
+```
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.3...v0.6.4

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.3"
+version = "0.6.4"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships #36: every published backend image from 0.5.0 to 0.6.3 could not boot (`python-multipart` missing, so `create_app()` raised at route registration).

Notes lead with that, since anyone who pulled 0.5.0 or later has an engine that cannot start, and state the decision on the old tags explicitly: they are left as they are — republishing a version number with different contents is worse than a tag that is honestly broken.