### PR TITLE
Enter accepts what a Makefile prompt offers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,11 +143,13 @@ version-update:  ## Set the version everywhere (asks when VERSION= is omitted)
 	  current=$$(grep -m1 '^version = ' apps/backend/pyproject.toml | sed 's/.*"\(.*\)"/\1/'); \
 	  major=$${current%%.*}; rest=$${current#*.}; \
 	  minor=$${rest%%.*}; patch=$${rest#*.}; \
+	  suggested="$$major.$$minor.$$((patch+1))"; \
 	  printf 'current version: %s\n' "$$current"; \
-	  printf 'suggestions:     %s.%s.%s (fixes only) | %s.%s.0 (features)\n' \
-	    "$$major" "$$minor" "$$((patch+1))" "$$major" "$$((minor+1))"; \
-	  printf 'new version (x.y.z): '; \
+	  printf 'suggestions:     %s (fixes only) | %s.%s.0 (features)\n' \
+	    "$$suggested" "$$major" "$$((minor+1))"; \
+	  printf 'new version (x.y.z) [%s]: ' "$$suggested"; \
 	  read -r v; \
+	  v=$${v:-$$suggested}; \
 	fi; \
 	v=$${v#v}; \
 	case "$$v" in \
@@ -174,6 +176,12 @@ version-update:  ## Set the version everywhere (asks when VERSION= is omitted)
 	$(MAKE) --no-print-directory version; \
 	echo "next: review with 'git diff', commit, then 'make version-tag'"
 
+# Interactive prompts in this file follow one convention: **Enter accepts what
+# is offered**, and the bracket shows it — `[Y/n]` for a yes/no, `[value]` for
+# a default. Nothing dangerous is offered by accident: `version-tag` asks
+# twice, and the second question is the only one that publishes anything —
+# asked right after printing what pushing will start. Answer `n` there and the
+# tag stays local.
 version-tag:  ## Create the annotated tag v<version> (clean tree required; asks first)
 	@test -z "$$(git status --porcelain)" || { \
 	  echo "the working tree is not clean — commit or stash first"; exit 1; }
@@ -201,10 +209,10 @@ version-tag:  ## Create the annotated tag v<version> (clean tree required; asks 
 	  echo " release notes and the published notes advertised a 404.)"; \
 	  exit 1; \
 	fi; \
-	printf 'create annotated tag v%s at %s (%s)? [y/N] ' \
+	printf 'create annotated tag v%s at %s (%s)? [Y/n] ' \
 	  "$$v" "$$(git rev-parse --short HEAD)" "$$(git branch --show-current)"; \
 	read -r answer; \
-	case "$$answer" in \
+	case "$${answer:-y}" in \
 	  [yY]*) ;; \
 	  *) echo "aborted — no tag created"; exit 1;; \
 	esac; \
@@ -214,9 +222,9 @@ version-tag:  ## Create the annotated tag v<version> (clean tree required; asks 
 	echo "Pushing it starts the release: CI, the four GHCR images, and a draft"; \
 	echo "release with the wheels, the extension zip and your notes attached."; \
 	echo "Nothing is published — the draft waits for you."; \
-	printf 'push v%s to origin now? [y/N] ' "$$v"; \
+	printf 'push v%s to origin now? [Y/n] ' "$$v"; \
 	read -r push; \
-	case "$$push" in \
+	case "$${push:-y}" in \
 	  [yY]*) \
 	    git push origin "v$$v" && \
 	    echo "pushed — follow it in Actions, then publish the draft release";; \

--- a/tests/test_makefile_prompts.py
+++ b/tests/test_makefile_prompts.py
@@ -1,0 +1,54 @@
+"""Every interactive prompt in the Makefile accepts Enter.
+
+Asked for directly: "It's nice with the Y and the N, but I would like to be
+able to press Enter to validate and not being forced to press Y."
+
+The convention is one line: **Enter accepts what is offered**, and the bracket
+says what that is — `[Y/n]` for a yes/no, `[value]` for a default. A prompt
+that reads an answer without providing a default breaks it, which is easy to
+reintroduce because each prompt is a separate blob of shell.
+
+Nothing dangerous rides on a bare Enter: `version-tag` asks twice, and the
+question that publishes is asked right after printing what pushing starts.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+
+MAKEFILE = (pathlib.Path(__file__).resolve().parents[1] / "Makefile").read_text()
+# Shell continuations joined, so one command reads as one line.
+FLAT = MAKEFILE.replace("\\\n", " ")
+READS = re.findall(r"read -r (\w+)", FLAT)
+
+
+def test_there_are_prompts_to_check():
+    """A guard on the guard: if the reads move or vanish, this file is testing
+    nothing and should be updated rather than silently passing."""
+    assert len(READS) >= 3, f"expected the version prompts, found {READS}"
+
+
+def test_every_prompt_has_a_default_so_enter_is_enough():
+    for variable in READS:
+        assert f"${{{variable}:-" in FLAT, (
+            f"`read -r {variable}` has no default: pressing Enter would fall "
+            f"through to the refusal branch. Use ${{{variable}:-y}} (or a "
+            f"value) so Enter accepts what the prompt offers."
+        )
+
+
+def test_a_yes_no_prompt_advertises_which_way_enter_goes():
+    """`[y/N]` promises that Enter declines. Since Enter now accepts, the
+    bracket has to say `[Y/n]` — a prompt that lies about its default is worse
+    than one that demands a keystroke."""
+    assert "[y/N]" not in MAKEFILE, "a prompt still advertises Enter as 'no'"
+    assert MAKEFILE.count("[Y/n]") >= 2
+
+
+def test_the_version_prompt_offers_the_patch_bump():
+    """`version-update` asks for a value, not a yes/no: Enter takes the patch
+    suggestion it just printed, and the bracket shows it."""
+    assert "new version (x.y.z) [%s]: " in MAKEFILE
+    # `$$` is Make's escape for a shell `$`, so the source reads `$${v:-...}`.
+    assert "v=$${v:-$$suggested}" in FLAT


### PR DESCRIPTION
From `work/coming/04`: *"It's nice with the Y and the N, but I would like to be able to press Enter to validate and not being forced to press Y."*

One convention, stated by the bracket: **`[Y/n]`** for a yes/no, **`[value]`** for a default.

`version-update` gets more than a flipped default — it had none, and an empty answer fell into `the version must look like x.y.z (got '')`. It now offers the patch bump it already prints, so the usual release is Enter, Enter.

Nothing dangerous rides on a bare Enter: `version-tag` still asks twice, and the second question — the only one that publishes — comes right after printing what pushing starts. `n` there keeps the tag local.

A test holds the convention (each prompt is its own blob of shell, and the next one added will not remember): every `read -r X` needs a `${X:-…}`, and no prompt may advertise `[y/N]` while Enter means yes.

Verified by executing the real fragments extracted from the Makefile: Enter creates the tag and pushes, `n` aborts at the first question.