### PR TITLE
Installing the MCP server without installing anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,13 +319,14 @@ exposes intention-level tools — not one per endpoint — to:
 
 The agent never needs shell access, yt-dlp syntax, or backend internals.
 
-```bash
-uv tool install content-mcp
+**Nothing to install.** `uvx` fetches the server on first use and keeps it
+current, so the client owns the whole lifecycle:
 
+```bash
 # Claude Code
 claude mcp add content \
   --env CONTENT_API_URL=http://localhost:8010 \
-  -- content-mcp
+  -- uvx content-mcp
 ```
 
 For Claude Desktop, Cursor, and other MCP clients using the standard JSON
@@ -335,11 +336,20 @@ shape:
 {
   "mcpServers": {
     "content": {
-      "command": "content-mcp",
+      "command": "uvx",
+      "args": ["content-mcp"],
       "env": { "CONTENT_API_URL": "http://localhost:8010" }
     }
   }
 }
+```
+
+Prefer a pinned executable on your PATH — for an offline machine, or to control
+when the version changes? Install it and name it directly
+(`"command": "content-mcp"`, or `-- content-mcp` for Claude Code):
+
+```bash
+uv tool install content-mcp      # or: pipx install content-mcp
 ```
 
 Then ask naturally:

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -28,15 +28,35 @@ than something a prompt can talk it into.
 
 ## Install
 
-The server is an ordinary Python application — nothing to clone:
+The server is an ordinary Python application — nothing to clone. There are two
+shapes, and which one you want depends on who should own the lifecycle.
+
+**Let the client fetch it (nothing installed).** `uvx` downloads the server on
+first use, caches it and keeps it current, so there is no step to forget and no
+version to upgrade by hand. This is the shortest path and the one to prefer:
 
 ```bash
-uv tool install content-mcp     # isolated, on your PATH — recommended
+uvx content-mcp --version       # 0.6.4 — fetched on the spot
+```
+
+Your MCP client then spawns `uvx content-mcp` instead of a binary (see
+*Connect it to your engine* below). `pipx run content-mcp` does the same if you
+use pipx.
+
+**Or install an executable on your PATH.** Pin the version, work offline, or
+just prefer a command you can run yourself:
+
+```bash
+uv tool install content-mcp     # isolated, on your PATH
 content-mcp --help
 
 # or
 pipx install content-mcp
 ```
+
+The trade-off is only who updates it: `uvx` follows PyPI, an installed tool
+stays where you put it until `uv tool upgrade content-mcp`. Both run the same
+wheel.
 
 [`content-mcp` on PyPI](https://pypi.org/project/content-mcp/) pulls
 [`content-sdk`](https://pypi.org/project/content-sdk/) as an ordinary
@@ -53,6 +73,10 @@ The server speaks stdio — your MCP client spawns it; you never run it by hand.
 ### Claude Code
 
 ```bash
+# nothing installed — uvx fetches it
+claude mcp add content --env CONTENT_API_URL=http://localhost:8010 -- uvx content-mcp
+
+# or, with the executable installed
 claude mcp add content --env CONTENT_API_URL=http://localhost:8010 -- content-mcp
 ```
 
@@ -65,12 +89,16 @@ any other client using the standard JSON shape:
 {
   "mcpServers": {
     "content": {
-      "command": "content-mcp",
+      "command": "uvx",
+      "args": ["content-mcp"],
       "env": { "CONTENT_API_URL": "http://localhost:8010" }
     }
   }
 }
 ```
+
+With the executable installed instead, drop the `args` and use
+`"command": "content-mcp"`.
 
 Then ask for something like *"analyze this YouTube URL and download the audio
 into my library"* — the expected flow is `get_config` → `analyze_source` →

--- a/apps/mcp/release-check.sh
+++ b/apps/mcp/release-check.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Release check for content-mcp — tests the PUBLISHED ARTIFACT, not the source tree.
+#
+# Why this exists: the repo's 39 unit tests all pass while the published package
+# is unusable. They import from the working tree, where the installed `mcp` is
+# whatever the dev environment happens to have. A user running `uvx content-mcp`
+# resolves dependencies from scratch, and can land on a version that does not
+# have the API the code imports. That gap is invisible to every test we own.
+#
+# Rule of thumb: unit tests prove the code is right; this proves the package is
+# installable. Both are needed, and only this one catches a floor that lies.
+#
+# Usage:
+#   ./release-check.sh                 # test the version on PyPI
+#   ./release-check.sh --local         # test the working tree, built and installed
+#   CONTENT_API_URL=... ./release-check.sh
+set -Eeuo pipefail
+
+PKG="content-mcp"
+# Pin the interpreter. Without this, `uv venv` picks whatever Python leads the
+# PATH in the current directory — miniconda 3.10 from one shell, 3.13 from
+# another — and the same script reports "unsatisfiable" or "all green"
+# depending on where it was launched. A check whose verdict moves with the cwd
+# is worse than no check: it produces confident false alarms.
+PYVER="${RELEASE_CHECK_PYTHON:-3.13}"
+API="${CONTENT_API_URL:-http://localhost:8010}"
+MODE="pypi"
+[[ "${1:-}" == "--local" ]] && MODE="local"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+# macOS ships no `timeout`. perl's alarm is present everywhere and needs no install.
+tmo() { local s="$1"; shift; perl -e 'alarm shift; exec @ARGV' "$s" "$@"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; PASS=$((PASS+1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$1"; [[ -n "${2:-}" ]] && printf '      %s\n' "$2"; FAIL=$((FAIL+1)); }
+head_() { printf '\n\033[1m%s\033[0m\n' "$1"; }
+
+head_ "1. Clean install, LOWEST allowed dependency versions (Python $PYVER)"
+# This is the test that fails today. `--resolution lowest-direct` installs the
+# oldest version each declared floor permits — exactly what a user with an older
+# resolver, an old lockfile, or a constrained environment will get. If the code
+# needs a newer API than the floor admits, it breaks here and nowhere else.
+if uv venv --python "$PYVER" "$WORK/low" >/dev/null 2>&1; then
+  if [[ "$MODE" == local ]]; then TARGET="$(cd "$(dirname "$0")" && pwd)"; else TARGET="$PKG"; fi
+  if uv pip install --python "$WORK/low/bin/python" --resolution lowest-direct "$TARGET" >"$WORK/low.log" 2>&1; then
+    ok "installs with lowest-direct resolution"
+    if "$WORK/low/bin/python" -c "import content_mcp.server" >"$WORK/low.import" 2>&1; then
+      ok "imports with the lowest allowed dependencies"
+    else
+      bad "IMPORT FAILS on the lowest allowed dependencies — the declared floor is a lie" \
+          "$(tail -2 "$WORK/low.import" | tr '\n' ' ')"
+      echo "      resolved: $("$WORK/low/bin/python" -c 'import importlib.metadata as m; print("mcp", m.version("mcp"))' 2>/dev/null || echo '?')"
+    fi
+  else
+    bad "install failed" "$(tail -2 "$WORK/low.log" | tr '\n' ' ')"
+  fi
+else
+  bad "uv venv unavailable"
+fi
+
+head_ "2. Clean install, current resolution"
+uv venv --python "$PYVER" "$WORK/cur" >/dev/null 2>&1
+if [[ "$MODE" == local ]]; then TARGET="$(cd "$(dirname "$0")" && pwd)"; else TARGET="$PKG"; fi
+if uv pip install --python "$WORK/cur/bin/python" "$TARGET" >"$WORK/cur.log" 2>&1; then
+  ok "installs"
+  PY="$WORK/cur/bin/python"
+  "$PY" -c "import content_mcp.server" 2>/dev/null && ok "imports" || bad "import fails"
+  V="$("$PY" -c 'import importlib.metadata as m; print(m.version("content-mcp"))' 2>/dev/null || echo '?')"
+  ok "version installed: $V"
+else
+  bad "install failed" "$(tail -2 "$WORK/cur.log" | tr '\n' ' ')"
+fi
+
+head_ "3. Console entry point"
+# The README tells people to run `uvx content-mcp`. If the entry point is
+# misdeclared the package installs fine and the documented command still fails.
+if [[ -x "$WORK/cur/bin/content-mcp" ]]; then ok "content-mcp executable present"
+else bad "console script 'content-mcp' missing from the install"; fi
+
+head_ "4. MCP handshake over stdio"
+# Speak the protocol the way a client does: initialize, then list tools.
+# A server that imports cleanly can still fail to negotiate or expose nothing.
+cat > "$WORK/handshake.py" <<'PY'
+import json, subprocess, sys, os
+env = dict(os.environ, CONTENT_API_URL=os.environ.get("CONTENT_API_URL", "http://localhost:8010"))
+p = subprocess.Popen([sys.argv[1]], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                     stderr=subprocess.DEVNULL, text=True, env=env, bufsize=1)
+def send(o): p.stdin.write(json.dumps(o) + "\n"); p.stdin.flush()
+send({"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+      "protocolVersion":"2025-06-18","capabilities":{},
+      "clientInfo":{"name":"release-check","version":"1"}}})
+init = json.loads(p.stdout.readline())
+send({"jsonrpc":"2.0","method":"notifications/initialized"})
+send({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}})
+tools = json.loads(p.stdout.readline())
+p.terminate()
+names = sorted(t["name"] for t in tools.get("result", {}).get("tools", []))
+print(json.dumps({"server": init.get("result", {}).get("serverInfo", {}), "tools": names}))
+PY
+if OUT=$(CONTENT_API_URL="$API" tmo 60 "$WORK/cur/bin/python" "$WORK/handshake.py" "$WORK/cur/bin/content-mcp" 2>/dev/null); then
+  ok "initialize + tools/list answered"
+  echo "      $(echo "$OUT" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["server"], "→", len(d["tools"]), "tools:", ", ".join(d["tools"]))')"
+  # The tool set is a public contract: a silently missing tool breaks callers.
+  for t in analyze_source generate get_job get_artifact list_capabilities get_config; do
+    echo "$OUT" | grep -q "\"$t\"" && ok "tool exposed: $t" || bad "TOOL MISSING: $t"
+  done
+else
+  bad "no MCP handshake — the server did not answer initialize/tools/list"
+fi
+
+head_ "5. Live engine, read-only"
+if curl -fsS --max-time 10 "$API/health" >/dev/null 2>&1 || curl -fsS --max-time 10 "$API/" >/dev/null 2>&1; then
+  ok "engine reachable at $API"
+else
+  bad "engine unreachable at $API — steps 4-5 only proved the server starts, not that it works"
+fi
+
+head_ "6. uvx path (what the README tells users to run)"
+if [[ "$MODE" == pypi ]]; then
+  if tmo 180 uvx --from "$PKG" content-mcp --help >/dev/null 2>&1 \
+     || echo '' | tmo 30 uvx "$PKG" >/dev/null 2>&1; then
+    ok "uvx content-mcp starts"
+  else
+    bad "uvx content-mcp fails — this is the exact first command a reader of the post will run"
+  fi
+else
+  echo "  – skipped in --local mode"
+fi
+
+printf '\n\033[1mResult: %d passed, %d failed\033[0m\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || { echo "Do not publish."; exit 1; }
+echo "Safe to publish."

--- a/docs/operations/mcp-registry.md
+++ b/docs/operations/mcp-registry.md
@@ -97,11 +97,38 @@ The entry should be there with the version that was just published.
 
 ## What being listed does and does not buy
 
-**Claude Code does not query any registry.** Servers are added by hand
-(`claude mcp add content --env CONTENT_API_URL=… -- content-mcp`). Registry
-presence does not make Content installable in one click; it makes it *findable
-by a human* who then runs that command. Anthropic's curated connector directory
-is a separate channel and a later target.
+**The registry is a catalogue, not an installer.** It holds metadata and
+*installation instructions*; the artifact itself stays on PyPI. Our entry says,
+in machine-readable form: this server is the PyPI package `content-mcp`, it
+speaks stdio, and it reads `CONTENT_API_URL` and `CONTENT_MCP_DOWNLOAD_DIR`.
+Everything a client needs to install and launch it without asking the user
+anything is therefore already published — whether a given client *does* that is
+the client's business, not ours.
+
+**Claude Code does not, as of 2026-08-22.** Checked rather than assumed:
+`claude mcp --help` offers `add`, `add-json`, `add-from-claude-desktop`, `get`,
+`list`, `login`, `logout`, `remove`, `serve` — no `search`, no `install`, no
+registry subcommand of any kind. Articles describing clients that "discover and
+install from the registry" are describing an intent, or another client's own
+registry. Re-run that one-line check before believing otherwise; it is the kind
+of thing that changes without an announcement reaching us.
+
+So registry presence makes Content *findable by a human*, who then runs:
+
+```bash
+claude mcp add content --env CONTENT_API_URL=… -- uvx content-mcp
+```
+
+`uvx` is what makes that a single step: no install precedes it, and the client
+owns the version. Anthropic's curated connector directory is a separate channel
+and a later target.
+
+**One field we deliberately do not set.** `packages[].runtimeHint` exists to
+tell a client which runtime to use (`uvx` would be ours). The schema asks for
+it only when `runtimeArguments` are present, which is not our case, and a sweep
+of the registry found no PyPI entry using it — too thin a convention to follow
+on speculation. If a client ever documents that it honours the hint, adding it
+is one line in `server.json`.
 
 Directories worth submitting to once the registry entry is live, in order of
 likely return:


### PR DESCRIPTION
Two questions, both answered against what was actually checked.

### A shorter install path

`uvx content-mcp` — the client spawns it, uv fetches the wheel on first use, caches it, and follows PyPI from then on. No install step, no version for the user to own.

Verified as a real MCP server rather than just `--version`: stdio handshake, nine tools, `get_config` answering against a live engine, all from `command: uvx`.

It becomes the first form in the root README and in the MCP README, with the installed executable kept second — offline machines, or pinning when the version moves. Same wheel either way; the difference is only who updates it.

### Can the registry install it for you?

No, and the runbook now says why in terms of what was verified. The registry is a **catalogue, not an installer**: it holds metadata and install instructions while the artifact stays on PyPI. Our entry already carries everything a client would need — PyPI package, stdio transport, both environment variables. Whether a client acts on it is the client's business.

**Claude Code does not, as of 2026-08-22.** `claude mcp --help` offers add, add-json, add-from-claude-desktop, get, list, login, logout, remove, serve — no registry subcommand at all. Articles describing clients that "discover and install from the registry" describe an intent, or another client's own registry. The runbook names the one-line check to re-run, since this changes without announcement.

Also recorded: why `packages[].runtimeHint` stays unset — it would be `uvx`, but the schema asks for it only alongside `runtimeArguments`, and no PyPI entry in the registry uses it.