### PR TITLE
The MCP server says what it does, what it does not, and what is next

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,19 @@ The normal tool journey is
 the agent's own machine are bounded by a single variable
 (`CONTENT_MCP_DOWNLOAD_DIR`, `~/Downloads/Content` by default): a destination
 pointing outside it is refused, not clamped — widening that is the operator's
-decision, not something a prompt can talk the server into. See the
-[MCP guide](apps/mcp/README.md) for every tool, resource, and verified
-behavior.
+decision, not something a prompt can talk the server into.
+
+**What it can and cannot do, briefly** — the
+[MCP guide](apps/mcp/README.md#what-it-supports-today) has the full three
+tables, and each row there was driven over stdio against a running engine
+rather than inferred:
+
+|  |  |
+| --- | --- |
+| **Works** | URLs and playlists · local files (uploaded to the engine, so a laptop can drive a NAS) · PDFs, read for their text layer · video, audio, subtitles, transcripts, summaries, translations, chapters, thumbnails, metadata, Markdown, PDF · delivery into your library · cookie-authenticated sources |
+| **Does not** | stdio only, no HTTP transport · no live progress (`get_job` is a poll) · no `.docx`/`.epub`/`.odt`/`.rtf`, no OCR for scans · no transcoding · no playlist sync · nothing deletes anything · [the API has no authentication](docs/architecture-decisions/0024-no-authentication-is-still-the-answer.md) |
+| **Needs a runner** | Summaries, translations and derived chapters want a local [Ollama](https://ollama.com) or a cloud key; transcripts want subtitles, or the optional Whisper runner. The engine reports these as `unavailable` up front rather than failing halfway |
+| **Coming** | [Retrying only what failed](docs/architecture-decisions/0025-retrying-only-what-failed.md) · [playlist sync](docs/roadmap/roadmap.md) · [retention](docs/architecture-decisions/0023-retention-and-reclaiming-disk.md) · more document readers |
 
 ### CLI — terminals, scripts, and cron
 

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -13,19 +13,6 @@ business logic**.
 any MCP client → content-mcp (this) → content_sdk → your Content engine (/api/v1)
 ```
 
-## Where downloaded files land
-
-`download_artifact` writes to the machine running this server — the counterpart
-to delivery, which writes to the engine's library. One variable bounds it:
-
-| Variable | Default | Role |
-| --- | --- | --- |
-| `CONTENT_MCP_DOWNLOAD_DIR` | `~/Downloads/Content` | The only directory this server may write to. Relative destinations resolve inside it; anything pointing outside is refused, not clamped |
-
-The refusal is deliberate. An MCP server writes to a real filesystem on an
-agent's say-so, so widening that is the operator's decision, taken once, rather
-than something a prompt can talk it into.
-
 ## Install
 
 The server is an ordinary Python application — nothing to clone. There are two
@@ -108,6 +95,69 @@ engine's delivery folder.
 Logs go to **stderr** (stdout carries only the MCP JSON-RPC framing), so a
 client's log pane shows them without corrupting the session.
 
+## What it supports today
+
+Everything below has been driven over stdio against a running engine, not
+inferred from the code.
+
+| You can ask for | Notes |
+| --- | --- |
+| **A URL** — a video, a playlist, a web page | Media through yt-dlp ([its supported sites](https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md)), pages through the reader |
+| **A file on the machine running this server** | Read here and **uploaded** to the engine, which is how a laptop drives a homelab box. `.txt`, `.md`, `.pdf` (its text layer) and media files |
+| **video · audio · subtitles** | Quality, codec, container, audio languages, SponsorBlock, clip cutting |
+| **transcript · summary · translation · chapters** | The AI-backed ones need a runner — see *what needs a runner* below |
+| **thumbnail · keyframes · metadata** | Published artwork, extracted frames, normalized facts |
+| **markdown · document_text · pdf** | A page, a document, or a rendering of another output |
+| **A whole playlist** | Ask with `scope: "each_item"`: one artifact per member, numbered in order |
+| **A destination in the library** | `delivery: {folder, filename}`; each artifact reports its `delivered_path` |
+| **The file on your own machine** | `download_artifact`, bounded by `CONTENT_MCP_DOWNLOAD_DIR` |
+| **Authenticated sources** | `credential` names a cookie file configured on the *server*; the secret never travels |
+
+**What needs a runner.** The engine reports a capability as `unavailable`
+rather than failing halfway, so ask `analyze_source` first and believe it.
+Summaries, translations and derived chapters need a local
+[Ollama](https://ollama.com) or a configured cloud key; transcripts need
+existing subtitles, or the optional Whisper runner for audio without them.
+
+## What it does not support
+
+Stated plainly, because finding out by trying is a bad first impression.
+
+| Not available | Why, and what to do instead |
+| --- | --- |
+| **HTTP/SSE transport** | stdio only. Your client spawns the process; a remote server is not exposed. |
+| **MCP prompts** | Not provided. The tool descriptions and the server instructions carry the guidance instead. |
+| **Live progress** | `get_job` is a status poll. The engine has an event stream, but no MCP notification carries it — a long download is opaque until it ends. |
+| **Job logs** | Not exposed. `get_job` gives the failing step and its reason, which is what an agent can act on; the raw logs stay on the engine. |
+| **Retrying only what failed** | `retry_job` re-runs the whole request. A decision is pending (ADR 0025). |
+| **`.docx`, `.epub`, `.odt`, `.rtf`** | Recognised and refused — each needs its own reader. |
+| **Scanned PDFs** | The text layer is read; a scan holds an image of words. That needs OCR, which the engine does not implement, and it says so rather than returning nothing. |
+| **Video transcoding** | Stream copy and remux only. A format change that requires re-encoding is refused as `option_not_supported`. |
+| **Playlist synchronization** | Content downloads a playlist; it does not keep a folder in step with one over time. |
+| **Deleting anything** | No tool removes an artifact, a job or a file. Retention is an operator concern (ADR 0023, proposed). |
+| **Authentication on the engine** | The V1 API has none (ADR 0024). Keep it on a trusted network or behind a reverse proxy — this server inherits whatever reach it has. |
+
+## What is coming
+
+Written down so the gaps read as a plan rather than as neglect. None of it is
+implemented; each links to where the decision lives.
+
+- **Retrying only what failed** — a twenty-video playlist with one failure
+  should cost one member, not twenty
+  ([ADR 0025](../../docs/architecture-decisions/0025-retrying-only-what-failed.md),
+  proposed).
+- **Playlist synchronization** — keeping a local folder in step with a playlist
+  as it changes ([M2](../../docs/roadmap/roadmap.md), the half not yet built).
+- **Retention** — reclaiming disk without touching the user's library
+  ([ADR 0023](../../docs/architecture-decisions/0023-retention-and-reclaiming-disk.md),
+  proposed).
+- **More document readers, and OCR** — the formats listed as refused above.
+- **HTTP transport** — stdio is what every client here speaks today; nothing
+  blocks the other one except a reason to build it.
+
+Something you need that is not here? The gap list is the roadmap's front door:
+[open an issue](https://github.com/LatentNoise/content/issues).
+
 ## Tools (intention-level, not one-per-endpoint)
 
 | Tool | Intent |
@@ -117,6 +167,7 @@ client's log pane shows them without corrupting the session.
 | `generate` | Start a job producing outputs from an `analysis_id`; an output spec may carry `delivery` (`mode`/`folder`/`filename`, ADR 0018) |
 | `get_job` | Job status; once terminal, its artifacts — user-facing names (ADR 0017) and `delivered_path` in the server library |
 | `cancel_job` | Cooperative cancellation |
+| `retry_job` | Run a finished job's request again, as a new job. The **whole** request — see *What is coming* for the finer version |
 | `list_jobs` | Recent jobs |
 | `get_artifact` | Artifact metadata; **small text is inlined**, larger/binary returns a download reference (never raw bytes over MCP) |
 | `get_config` | Request-building context: credential ids, whether delivery-by-default is on, the existing library folders |
@@ -126,6 +177,56 @@ client's log pane shows them without corrupting the session.
 `content://analyses/{id}`, `content://jobs/{id}`, `content://artifacts/{id}` —
 JSON views for a host to attach as context. Prompts are intentionally not
 provided yet.
+
+## Where downloaded files land
+
+`download_artifact` writes to the machine running this server — the counterpart
+to delivery, which writes to the engine's library. One variable bounds it:
+
+| Variable | Default | Role |
+| --- | --- | --- |
+| `CONTENT_MCP_DOWNLOAD_DIR` | `~/Downloads/Content` | The only directory this server may write to. Relative destinations resolve inside it; anything pointing outside is refused, not clamped |
+
+The refusal is deliberate. An MCP server writes to a real filesystem on an
+agent's say-so, so widening that is the operator's decision, taken once, rather
+than something a prompt can talk it into.
+
+## When something goes wrong
+
+Every tool translates the SDK's exceptions into something an agent can act on,
+because the alternative is what this server used to say when the engine was not
+running: `[Errno 61] Connection refused`. It names neither what failed nor what
+to do, and it is the **first** thing a new user meets — the engine listens on
+`8010` on the host and `8000` only inside its container, so pointing at the
+wrong one is the ordinary mistake.
+
+| Situation | What the caller is told |
+| --- | --- |
+| The engine is not reachable | Which URL was tried, that `docker compose up -d` starts it, that `CONTENT_API_URL` moves it, and the 8010/8000 distinction |
+| An analysis has expired | That analyses are kept for a limited time, and to call `analyze_source` again |
+| The engine refused the request | The stable error codes (`output_type_not_supported`, …) and the body |
+| An output spec is malformed | Caught *before* the round trip, with an example of a correct one |
+
+## Design
+
+- `service.py` — the intention logic; takes an SDK client, returns JSON. No MCP
+  imports, no HTTP. Fully unit-tested over a mock transport.
+- `server.py` — thin wiring: registers the tools/resources on an `MCPServer` and
+  runs stdio. `content-mcp` → `content_mcp.server:main`.
+- The layering is enforced by tests: the MCP server may import `content_sdk`
+  only — never an HTTP client, never backend internals
+  (`tests/test_layering.py` at the repo root).
+
+## Local files, both directions
+
+A path you give `analyze_source` is a path on the machine running **this
+server**, never on the engine: the file is read here and uploaded, which is the
+only way a local file becomes usable by an engine running elsewhere. Identical
+path strings on two machines do not imply identical filesystems, so the path is
+never passed through untouched.
+
+`download_artifact` is the mirror image — it brings a finished artifact back to
+this machine, bounded by `CONTENT_MCP_DOWNLOAD_DIR` (see above).
 
 ## For development
 
@@ -165,39 +266,3 @@ Build the distributions with `make wheels` (they land in `dist/`).
   Re-run it after any transport change; the in-process suites above never reach
   a closed socket, which is exactly how the error-message defect survived.
 
-## When something goes wrong
-
-Every tool translates the SDK's exceptions into something an agent can act on,
-because the alternative is what this server used to say when the engine was not
-running: `[Errno 61] Connection refused`. It names neither what failed nor what
-to do, and it is the **first** thing a new user meets — the engine listens on
-`8010` on the host and `8000` only inside its container, so pointing at the
-wrong one is the ordinary mistake.
-
-| Situation | What the caller is told |
-| --- | --- |
-| The engine is not reachable | Which URL was tried, that `docker compose up -d` starts it, that `CONTENT_API_URL` moves it, and the 8010/8000 distinction |
-| An analysis has expired | That analyses are kept for a limited time, and to call `analyze_source` again |
-| The engine refused the request | The stable error codes (`output_type_not_supported`, …) and the body |
-| An output spec is malformed | Caught *before* the round trip, with an example of a correct one |
-
-## Design
-
-- `service.py` — the intention logic; takes an SDK client, returns JSON. No MCP
-  imports, no HTTP. Fully unit-tested over a mock transport.
-- `server.py` — thin wiring: registers the tools/resources on an `MCPServer` and
-  runs stdio. `content-mcp` → `content_mcp.server:main`.
-- The layering is enforced by tests: the MCP server may import `content_sdk`
-  only — never an HTTP client, never backend internals
-  (`tests/test_layering.py` at the repo root).
-
-## Local files, both directions
-
-A path you give `analyze_source` is a path on the machine running **this
-server**, never on the engine: the file is read here and uploaded, which is the
-only way a local file becomes usable by an engine running elsewhere. Identical
-path strings on two machines do not imply identical filesystems, so the path is
-never passed through untouched.
-
-`download_artifact` is the mirror image — it brings a finished artifact back to
-this machine, bounded by `CONTENT_MCP_DOWNLOAD_DIR` (see above).

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -194,6 +194,16 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         return service.download_artifact(client, artifact_id, destination)
 
     @tool()
+    def retry_job(job_id: str) -> dict[str, Any]:
+        """Run a finished job's request again, as a new job.
+
+        Re-runs the *whole* request: a playlist where one member failed
+        re-downloads every member. Worth it for a transient failure, wasteful
+        for a large collection — read the failure in `get_job` first.
+        """
+        return service.retry_job(client, job_id)
+
+    @tool()
     def get_config() -> dict[str, Any]:
         """Server-side context for building requests: credential ids for
         authenticated sources, whether delivery-by-default is on, and the

--- a/apps/mcp/content_mcp/service.py
+++ b/apps/mcp/content_mcp/service.py
@@ -215,6 +215,23 @@ def cancel_job(client: ContentClient, job_id: str) -> dict[str, Any]:
     return client.cancel(job_id)
 
 
+def retry_job(client: ContentClient, job_id: str) -> dict[str, Any]:
+    """Run a finished job's request again, as a new job.
+
+    `cancel_job` had no counterpart: an agent that watched a job fail could
+    report the failure and nothing else, when "try that again" is the obvious
+    next move for a transient one (a 429 from the provider, a network blip).
+
+    It re-runs the **whole** request — a playlist where one member failed
+    downloads all of them again. Retrying only what failed is a decision still
+    being made (ADR 0025), so this is deliberately the coarse version rather
+    than a guess at the fine one. Judge the cost before calling it on a
+    collection.
+    """
+    job = client.retry(job_id)
+    return {"job_id": job.id, "status": job.status, "retry_of": job_id}
+
+
 def get_config(client: ContentClient) -> dict[str, Any]:
     """What an agent needs to parameterize requests: the credential ids for
     authenticated sources, whether artifacts are delivered into the server

--- a/apps/mcp/tests/test_service.py
+++ b/apps/mcp/tests/test_service.py
@@ -284,3 +284,24 @@ def test_a_succeeded_job_carries_no_failure_noise():
     result = service.get_job(_api(handler), "job_ok")
     assert "failures" not in result
     assert result["error"] == ""
+
+
+def test_retry_job_reruns_the_request_and_names_its_ancestor():
+    """`cancel_job` had no counterpart: an agent that watched a job fail could
+    report the failure and nothing else. The answer carries `retry_of` so the
+    agent can tell the user which run this replaces."""
+    seen: dict = {}
+
+    def handler(request):
+        seen["path"] = request.url.path
+        seen["method"] = request.method
+        return httpx.Response(201, json={"job_id": "job_new", "status": "queued"})
+
+    client = ContentClient(
+        "http://engine",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+    answer = service.retry_job(client, "job_old")
+
+    assert seen == {"path": "/api/v1/jobs/job_old/retry", "method": "POST"}
+    assert answer == {"job_id": "job_new", "status": "queued", "retry_of": "job_old"}


### PR DESCRIPTION
The surface being put forward publicly was documented as a tool list. A tool list answers *how do I call it* and leaves the two questions a newcomer actually has: **can it do the thing I want**, and **what will I discover the hard way**.

### Three tables in `apps/mcp/README.md`

- **What it supports today** — URLs and playlists, local files uploaded from the machine running the server, PDFs read for their text layer, the twelve output types, delivery into a library, cookie-authenticated sources. Every row was driven over stdio against a running engine, not inferred from the code.
- **What it does not support** — stdio only, no live progress, no `.docx`/`.epub`/`.odt`/`.rtf`, no OCR for scans, no transcoding, no playlist sync, nothing deletes anything, and an API with no authentication.
- **What is coming** — each line pointing at the ADR or milestone where the decision lives, so a gap reads as a plan rather than as neglect.

The AI-backed outputs get their own paragraph: `summary` being unavailable on an engine with no Ollama is the most likely first surprise, and the engine already answers it up front rather than failing halfway.

Sections reordered for someone arriving cold — install, connect, what it can do, then the reference. The download-directory detail moved out of second place, where it met readers before they had a server running.

### `retry_job`

`cancel_job` had no counterpart: an agent watching a job fail could report the failure and nothing else, when *try that again* is the obvious move for a 429 or a network blip. It re-runs the **whole** request and says so — retrying only what failed is ADR 0025, and a guess at the fine version would be worse than an honest coarse one.

### Root README

A four-row condensation of the same tables, since that is the page the announcement points at.

Verified: 10 tools over stdio against the live engine; `retry_job` created a real re-run (cancelled immediately after).
