### PR TITLE
Version 0.6.5

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.4"
+    org.opencontainers.image.version="0.6.5"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.4"
+version = "0.6.5"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.4"
+version = "0.6.5"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.4"]
+dependencies = ["content-sdk==0.6.5"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.4", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.5", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.4"
+version = "0.6.5"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.4", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.5", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.4"
+version = "0.6.5"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.5.md
+++ b/docs/releases/v0.6.5.md
@@ -1,0 +1,73 @@
+The MCP server documents itself honestly, and gains the tool that was missing
+beside `cancel_job`.
+
+## `retry_job`
+
+An agent that watched a job fail could report the failure and nothing else.
+`cancel_job` existed; its counterpart did not — and "try that again" is the
+obvious move for a transient failure, a 429 from a provider or a network blip.
+
+```text
+retry_job(job_id) → a new job, carrying retry_of
+```
+
+It re-runs the **whole** request, and the tool description says so: a playlist
+where one member failed downloads every member again. Retrying only what failed
+is a decision still being made
+([ADR 0025](https://github.com/LatentNoise/content/blob/main/docs/architecture-decisions/0025-retrying-only-what-failed.md),
+proposed in this release), and a guess at the fine version would be worse than
+an honest coarse one.
+
+## What the server supports, does not support, and will
+
+`apps/mcp/README.md` — which is also the package page on PyPI — led with a tool
+list. That answers *how do I call it* and leaves the two questions someone
+actually has: can it do the thing I want, and what will I find out the hard way.
+
+It now opens with three tables:
+
+- **What it supports today** — URLs and playlists, local files uploaded from
+  the machine running the server, PDFs read for their text layer, the twelve
+  output types, delivery into a library, cookie-authenticated sources. Every
+  row was driven over stdio against a running engine, not inferred from code.
+- **What it does not support** — stdio only, no live progress, no `.docx` /
+  `.epub` / `.odt` / `.rtf`, no OCR for scans, no transcoding, no playlist
+  sync, nothing deletes anything, and an API with no authentication.
+- **What is coming** — each line pointing at the ADR or milestone where the
+  decision lives, so a gap reads as a plan rather than as neglect.
+
+The AI-backed outputs get their own paragraph, because `summary` being
+unavailable on an engine with no Ollama is the most likely first surprise — and
+the engine already answers it up front, reporting the capability as
+`unavailable` instead of failing halfway.
+
+## Installing it without installing it
+
+`uvx content-mcp` is now the first form the docs show. The client spawns it, uv
+fetches the wheel on first use and follows PyPI from then on:
+
+```json
+{ "mcpServers": { "content": {
+    "command": "uvx", "args": ["content-mcp"],
+    "env": { "CONTENT_API_URL": "http://localhost:8010" } } } }
+```
+
+`uv tool install` and `pipx install` remain, for an offline machine or to pin
+the version. Same wheel; the difference is only who updates it.
+
+## Also
+
+- **ADR 0025** ships as a proposal: retrying only what failed, and why the
+  obvious design ("skip the steps that succeeded") is unsound while
+  intermediates are job-local and the cross-job cache is off.
+- **Makefile prompts accept Enter.** `[Y/n]` for a yes/no, `[value]` for a
+  default; `version-update` offers the patch bump it was already printing.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+uv tool install --reinstall --refresh content-mcp    # or nothing, with uvx
+```
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.4...v0.6.5

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.4"
+version = "0.6.5"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships the MCP consolidation (#41) and ADR 0025 (#40).

Released rather than held, because the documentation merged on main now describes **ten** tools while the published package has nine — `retry_job` exists only in the source tree. And `apps/mcp/README.md` is the PyPI package page: the three tables (supports / does not support / coming) reach users only through a release.