### PR TITLE
A PDF states its title once, and looks like this decade

### DIFF
--- a/apps/backend/content/documents/markdown.py
+++ b/apps/backend/content/documents/markdown.py
@@ -168,4 +168,40 @@ def parse_markdown(markdown: str, *, title: str = "") -> Document:
 
     flush_paragraph()
     flush_list()
+    _drop_repeated_title(document)
     return document
+
+
+def _drop_repeated_title(document: Document) -> None:
+    """Collapse a title that the document states twice in a row.
+
+    Observed in a real PDF: the heading appeared, a rule, then the very same
+    heading and another rule. It happens whenever something writes a header
+    above a body that already titles itself — and an LLM summary titles itself
+    almost every time, because that is what "format the output as Markdown"
+    produces.
+
+    Only the narrow case is touched: two headings of the same level with the
+    same text, adjacent or separated by nothing but rules. That is never a
+    document someone meant to write. Two identical headings further apart are
+    left alone — a recurring section title is a legitimate shape, and guessing
+    at it would be the renderer editing the author.
+    """
+    heads = [i for i, b in enumerate(document.blocks) if b.kind == HEADING]
+    for first, second in zip(heads, heads[1:]):
+        between = document.blocks[first + 1 : second]
+        if any(b.kind != RULE for b in between):
+            continue
+        a, b = document.blocks[first], document.blocks[second]
+        if a.level != b.level:
+            continue
+        if _spans_text(a.spans).strip() != _spans_text(b.spans).strip():
+            continue
+        # Keep the first heading and drop the duplicate with the rules it
+        # dragged along, so the page does not end up with a stray double line.
+        del document.blocks[first + 1 : second + 1]
+        return
+
+
+def _spans_text(spans) -> str:
+    return "".join(s.text for s in spans)

--- a/apps/backend/content/processors/pdf/templates/default.typ
+++ b/apps/backend/content/processors/pdf/templates/default.typ
@@ -18,16 +18,70 @@
 #let doc = json("document.json")
 #let meta = json("meta.json")
 
-#set page(paper: meta.page_size, margin: 2.2cm)
-#set text(size: 10.5pt, hyphenate: true)
-#set par(justify: true, leading: 0.65em)
-#show heading: it => block(above: 1.1em, below: 0.55em, it)
-#show link: it => text(fill: rgb("#1a4fa0"), it)
+// --- palette and type scale -------------------------------------------------
+//
+// One accent, one ink, one muted grey. A document that a person will read on a
+// screen and occasionally print: enough contrast to survive a laser printer,
+// not so much that a wall of text becomes a wall of black.
+#let ink = rgb("#14181f")
+#let muted = rgb("#5b6572")
+#let accent = rgb("#2f5bd7")
+#let hairline = rgb("#dfe3e9")
+
+#set page(
+  paper: meta.page_size,
+  margin: (x: 2.4cm, y: 2.6cm),
+  // A discreet folio, and nothing else in the furniture. Page one carries no
+  // number: a one-page summary with "1" at the foot looks like a fragment.
+  footer: context {
+    let n = counter(page).get().first()
+    if n > 1 {
+      align(center, text(size: 8.5pt, fill: muted, str(n)))
+    }
+  },
+)
+
+// Libertinus is the most readable face shipped in the image, and the only one
+// here that does not look like a 1994 manual. The fallbacks matter: the glyph
+// policy upstream may have substituted characters, and DejaVu covers more.
+#set text(
+  font: ("Libertinus Serif", "DejaVu Serif", "DejaVu Sans"),
+  size: 10.5pt,
+  fill: ink,
+  hyphenate: true,
+)
+#set par(justify: true, leading: 0.72em, spacing: 1.15em, first-line-indent: 0pt)
+
+#show heading: set text(fill: ink)
+#show heading.where(level: 1): it => block(
+  above: 0em, below: 0.9em,
+  {
+    text(size: 20pt, weight: 600, it.body)
+    // A hairline under the document title, not a full rule: it separates
+    // without shouting, and it never repeats down the page.
+    v(0.18em)
+    line(length: 100%, stroke: 0.6pt + hairline)
+  },
+)
+#show heading.where(level: 2): it => block(
+  above: 1.5em, below: 0.55em,
+  text(size: 13.5pt, weight: 600, it.body),
+)
+// Level 3 stays darker than the body it introduces. Greying it out read as
+// *less* important than the list underneath — a heading that recedes behind
+// its own content is a hierarchy upside down.
+#show heading.where(level: 3): it => block(
+  above: 1.3em, below: 0.45em,
+  text(size: 11pt, weight: 600, fill: accent.darken(15%), it.body),
+)
+
+#show link: it => text(fill: accent, it)
+#set list(marker: (text(fill: accent, sym.bullet), text(fill: muted, "–")), spacing: 0.85em)
+#set enum(spacing: 0.85em)
 
 #if meta.title != "" {
   set document(title: meta.title)
 }
-
 // A span is data: text plus flags. Marks are applied by wrapping the *value*,
 // so nothing in `s.text` is ever parsed as Typst.
 #let render-span(s) = {
@@ -52,12 +106,21 @@
   } else if kind == "numbered" {
     enum(..b.items.map(i => spans(i)))
   } else if kind == "quote" {
-    block(inset: (left: 1em), stroke: (left: 2pt + luma(200)))[
-      #text(fill: luma(70), spans(b.spans))
-    ]
+    block(
+      inset: (left: 1.1em, y: 0.2em),
+      stroke: (left: 2pt + accent.lighten(45%)),
+      text(fill: muted, style: "italic", spans(b.spans)),
+    )
   } else if kind == "code" {
-    block(fill: luma(246), inset: 8pt, radius: 3pt, width: 100%, raw(b.text))
+    block(
+      fill: rgb("#f6f7f9"),
+      stroke: 0.5pt + hairline,
+      inset: 9pt,
+      radius: 4pt,
+      width: 100%,
+      text(font: ("DejaVu Sans Mono",), size: 9pt, raw(b.text)),
+    )
   } else if kind == "rule" {
-    block(above: 0.9em, below: 0.9em, line(length: 100%, stroke: 0.5pt + luma(200)))
+    block(above: 1.4em, below: 1.4em, line(length: 100%, stroke: 0.6pt + hairline))
   }
 }

--- a/apps/backend/tests/test_document_model.py
+++ b/apps/backend/tests/test_document_model.py
@@ -224,3 +224,67 @@ def test_quote_and_rule_survive_the_round_trip():
     assert payload["blocks"][1] == {"kind": RULE}
     assert document.blocks[0].spans[0].text == "quoted"
     assert parse_markdown("para").blocks[0].kind == PARAGRAPH
+
+
+# --- a title stated twice --------------------------------------------------------
+
+
+def test_a_title_repeated_immediately_is_collapsed():
+    """Seen in a real PDF: the heading, a rule, the same heading, another rule.
+
+    It happens whenever something writes a header above a body that already
+    titles itself — and an LLM summary titles itself almost every time, since
+    that is what "format the output as Markdown" produces. The duplicate rule
+    goes with it, so the page does not keep a stray double line.
+    """
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown(
+        "# Content — README summary\n\n---\n\n"
+        "# Content — README summary\n\n---\n\nBody text.",
+        title="Content — README summary",
+    )
+    headings = [b for b in document.blocks if b.kind == "heading"]
+    assert len(headings) == 1
+    assert sum(1 for b in document.blocks if b.kind == "rule") == 1
+
+
+def test_two_identical_headings_in_a_row_collapse_without_a_rule():
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown("# Titre\n\n# Titre\n\nTexte.", title="")
+    assert len([b for b in document.blocks if b.kind == "heading"]) == 1
+
+
+def test_the_same_title_further_down_is_left_alone():
+    """A recurring section title is a legitimate shape. Collapsing it would be
+    the renderer editing the author, which is a different job."""
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown("# Notes\n\nA.\n\n# Notes\n\nB.", title="")
+    assert len([b for b in document.blocks if b.kind == "heading"]) == 2
+
+
+def test_different_titles_or_levels_are_left_alone():
+    from content.documents.markdown import parse_markdown
+
+    assert (
+        len(
+            [
+                b
+                for b in parse_markdown("# A\n\n# B\n\nx.", title="").blocks
+                if b.kind == "heading"
+            ]
+        )
+        == 2
+    )
+    assert (
+        len(
+            [
+                b
+                for b in parse_markdown("# T\n\n## T\n\nx.", title="").blocks
+                if b.kind == "heading"
+            ]
+        )
+        == 2
+    )


### PR DESCRIPTION
From a screenshot of a generated PDF showing the title twice.

### The doubled title is not the renderer

Neither backend draws the title into the body — Typst's template only sets it as document metadata, ReportLab passes it to `SimpleDocTemplate`, and `parse_markdown` already documents that the title is *not* injected. Rendering a one-heading document gives a one-heading PDF; verified before touching anything.

**The source carried the heading twice.** That happens whenever something writes a header above a body that titles itself — and an LLM summary titles itself almost every time, since that is what *format the output as Markdown* produces. So the parser now collapses the narrow case: two headings, same level, same text, adjacent or separated by nothing but rules. The orphaned rule goes with the duplicate.

Deliberately narrow: the same title further down is left alone. A recurring section heading is a legitimate shape, and folding it would be the renderer editing the author.

### The typography

The template was Typst's defaults plus four lines. It now has a small design: Libertinus for the body, one accent / one ink / one muted grey, a 20pt title over a hairline instead of a rule that repeats down the page, coloured list markers, italic quotes behind an accent rule, code in a bordered rounded block, and a folio that starts at page two.

One fix worth naming: level-3 headings were grey, which read as *less* important than the list underneath — a hierarchy upside down. They now keep their weight.

The security boundary is untouched: user text still arrives as JSON and is placed by `strong()`/`emph()`/`link()`, never concatenated into markup.

Checked by rendering the same document before and after and **looking at both**.

Note: this restyles the Typst path. ReportLab, the fallback when Typst is absent, keeps its own styles — worth aligning later.