### PR TITLE
An uploaded file says where it went and how long it stays

### DIFF
--- a/apps/backend/content/api/app.py
+++ b/apps/backend/content/api/app.py
@@ -520,6 +520,18 @@ def create_app(
             # default, so a client can show the effective destination before
             # submitting instead of guessing.
             "delivery": {"by_default": settings.delivery_default},
+            # ADR 0020. A client that uploads bytes is entitled to know what
+            # happens to them: how long they are kept and how much it may send.
+            # Without this the policy exists only in the operator's .env, and a
+            # caller sending a file to somebody else's machine has to take the
+            # retention on trust — the one part of a remote engine that should
+            # never be implicit.
+            "uploads": {
+                "ttl_hours": settings.upload_ttl_hours,
+                "expire_from": "last_use",
+                "max_bytes": settings.max_upload_bytes,
+                "total_bytes": settings.uploads_total_bytes,
+            },
         }
 
     @app.get("/api/v1/folders", tags=["system"])

--- a/apps/backend/content/documents/markdown.py
+++ b/apps/backend/content/documents/markdown.py
@@ -168,4 +168,40 @@ def parse_markdown(markdown: str, *, title: str = "") -> Document:
 
     flush_paragraph()
     flush_list()
+    _drop_repeated_title(document)
     return document
+
+
+def _drop_repeated_title(document: Document) -> None:
+    """Collapse a title that the document states twice in a row.
+
+    Observed in a real PDF: the heading appeared, a rule, then the very same
+    heading and another rule. It happens whenever something writes a header
+    above a body that already titles itself — and an LLM summary titles itself
+    almost every time, because that is what "format the output as Markdown"
+    produces.
+
+    Only the narrow case is touched: two headings of the same level with the
+    same text, adjacent or separated by nothing but rules. That is never a
+    document someone meant to write. Two identical headings further apart are
+    left alone — a recurring section title is a legitimate shape, and guessing
+    at it would be the renderer editing the author.
+    """
+    heads = [i for i, b in enumerate(document.blocks) if b.kind == HEADING]
+    for first, second in zip(heads, heads[1:]):
+        between = document.blocks[first + 1 : second]
+        if any(b.kind != RULE for b in between):
+            continue
+        a, b = document.blocks[first], document.blocks[second]
+        if a.level != b.level:
+            continue
+        if _spans_text(a.spans).strip() != _spans_text(b.spans).strip():
+            continue
+        # Keep the first heading and drop the duplicate with the rules it
+        # dragged along, so the page does not end up with a stray double line.
+        del document.blocks[first + 1 : second + 1]
+        return
+
+
+def _spans_text(spans) -> str:
+    return "".join(s.text for s in spans)

--- a/apps/backend/content/processors/pdf/templates/default.typ
+++ b/apps/backend/content/processors/pdf/templates/default.typ
@@ -18,16 +18,70 @@
 #let doc = json("document.json")
 #let meta = json("meta.json")
 
-#set page(paper: meta.page_size, margin: 2.2cm)
-#set text(size: 10.5pt, hyphenate: true)
-#set par(justify: true, leading: 0.65em)
-#show heading: it => block(above: 1.1em, below: 0.55em, it)
-#show link: it => text(fill: rgb("#1a4fa0"), it)
+// --- palette and type scale -------------------------------------------------
+//
+// One accent, one ink, one muted grey. A document that a person will read on a
+// screen and occasionally print: enough contrast to survive a laser printer,
+// not so much that a wall of text becomes a wall of black.
+#let ink = rgb("#14181f")
+#let muted = rgb("#5b6572")
+#let accent = rgb("#2f5bd7")
+#let hairline = rgb("#dfe3e9")
+
+#set page(
+  paper: meta.page_size,
+  margin: (x: 2.4cm, y: 2.6cm),
+  // A discreet folio, and nothing else in the furniture. Page one carries no
+  // number: a one-page summary with "1" at the foot looks like a fragment.
+  footer: context {
+    let n = counter(page).get().first()
+    if n > 1 {
+      align(center, text(size: 8.5pt, fill: muted, str(n)))
+    }
+  },
+)
+
+// Libertinus is the most readable face shipped in the image, and the only one
+// here that does not look like a 1994 manual. The fallbacks matter: the glyph
+// policy upstream may have substituted characters, and DejaVu covers more.
+#set text(
+  font: ("Libertinus Serif", "DejaVu Serif", "DejaVu Sans"),
+  size: 10.5pt,
+  fill: ink,
+  hyphenate: true,
+)
+#set par(justify: true, leading: 0.72em, spacing: 1.15em, first-line-indent: 0pt)
+
+#show heading: set text(fill: ink)
+#show heading.where(level: 1): it => block(
+  above: 0em, below: 0.9em,
+  {
+    text(size: 20pt, weight: 600, it.body)
+    // A hairline under the document title, not a full rule: it separates
+    // without shouting, and it never repeats down the page.
+    v(0.18em)
+    line(length: 100%, stroke: 0.6pt + hairline)
+  },
+)
+#show heading.where(level: 2): it => block(
+  above: 1.5em, below: 0.55em,
+  text(size: 13.5pt, weight: 600, it.body),
+)
+// Level 3 stays darker than the body it introduces. Greying it out read as
+// *less* important than the list underneath — a heading that recedes behind
+// its own content is a hierarchy upside down.
+#show heading.where(level: 3): it => block(
+  above: 1.3em, below: 0.45em,
+  text(size: 11pt, weight: 600, fill: accent.darken(15%), it.body),
+)
+
+#show link: it => text(fill: accent, it)
+#set list(marker: (text(fill: accent, sym.bullet), text(fill: muted, "–")), spacing: 0.85em)
+#set enum(spacing: 0.85em)
 
 #if meta.title != "" {
   set document(title: meta.title)
 }
-
 // A span is data: text plus flags. Marks are applied by wrapping the *value*,
 // so nothing in `s.text` is ever parsed as Typst.
 #let render-span(s) = {
@@ -52,12 +106,21 @@
   } else if kind == "numbered" {
     enum(..b.items.map(i => spans(i)))
   } else if kind == "quote" {
-    block(inset: (left: 1em), stroke: (left: 2pt + luma(200)))[
-      #text(fill: luma(70), spans(b.spans))
-    ]
+    block(
+      inset: (left: 1.1em, y: 0.2em),
+      stroke: (left: 2pt + accent.lighten(45%)),
+      text(fill: muted, style: "italic", spans(b.spans)),
+    )
   } else if kind == "code" {
-    block(fill: luma(246), inset: 8pt, radius: 3pt, width: 100%, raw(b.text))
+    block(
+      fill: rgb("#f6f7f9"),
+      stroke: 0.5pt + hairline,
+      inset: 9pt,
+      radius: 4pt,
+      width: 100%,
+      text(font: ("DejaVu Sans Mono",), size: 9pt, raw(b.text)),
+    )
   } else if kind == "rule" {
-    block(above: 0.9em, below: 0.9em, line(length: 100%, stroke: 0.5pt + luma(200)))
+    block(above: 1.4em, below: 1.4em, line(length: 100%, stroke: 0.6pt + hairline))
   }
 }

--- a/apps/backend/tests/test_document_model.py
+++ b/apps/backend/tests/test_document_model.py
@@ -224,3 +224,67 @@ def test_quote_and_rule_survive_the_round_trip():
     assert payload["blocks"][1] == {"kind": RULE}
     assert document.blocks[0].spans[0].text == "quoted"
     assert parse_markdown("para").blocks[0].kind == PARAGRAPH
+
+
+# --- a title stated twice --------------------------------------------------------
+
+
+def test_a_title_repeated_immediately_is_collapsed():
+    """Seen in a real PDF: the heading, a rule, the same heading, another rule.
+
+    It happens whenever something writes a header above a body that already
+    titles itself — and an LLM summary titles itself almost every time, since
+    that is what "format the output as Markdown" produces. The duplicate rule
+    goes with it, so the page does not keep a stray double line.
+    """
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown(
+        "# Content — README summary\n\n---\n\n"
+        "# Content — README summary\n\n---\n\nBody text.",
+        title="Content — README summary",
+    )
+    headings = [b for b in document.blocks if b.kind == "heading"]
+    assert len(headings) == 1
+    assert sum(1 for b in document.blocks if b.kind == "rule") == 1
+
+
+def test_two_identical_headings_in_a_row_collapse_without_a_rule():
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown("# Titre\n\n# Titre\n\nTexte.", title="")
+    assert len([b for b in document.blocks if b.kind == "heading"]) == 1
+
+
+def test_the_same_title_further_down_is_left_alone():
+    """A recurring section title is a legitimate shape. Collapsing it would be
+    the renderer editing the author, which is a different job."""
+    from content.documents.markdown import parse_markdown
+
+    document = parse_markdown("# Notes\n\nA.\n\n# Notes\n\nB.", title="")
+    assert len([b for b in document.blocks if b.kind == "heading"]) == 2
+
+
+def test_different_titles_or_levels_are_left_alone():
+    from content.documents.markdown import parse_markdown
+
+    assert (
+        len(
+            [
+                b
+                for b in parse_markdown("# A\n\n# B\n\nx.", title="").blocks
+                if b.kind == "heading"
+            ]
+        )
+        == 2
+    )
+    assert (
+        len(
+            [
+                b
+                for b in parse_markdown("# T\n\n## T\n\nx.", title="").blocks
+                if b.kind == "heading"
+            ]
+        )
+        == 2
+    )

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -111,6 +111,7 @@ inferred from the code.
 | **A whole playlist** | Ask with `scope: "each_item"`: one artifact per member, numbered in order |
 | **A destination in the library** | `delivery: {folder, filename}`; each artifact reports its `delivered_path` |
 | **The file on your own machine** | `download_artifact`, bounded by `CONTENT_MCP_DOWNLOAD_DIR` |
+| **To take an upload back** | `delete_upload` removes bytes sent from this machine before the TTL runs out |
 | **Authenticated sources** | `credential` names a cookie file configured on the *server*; the secret never travels |
 
 **What needs a runner.** The engine reports a capability as `unavailable`
@@ -134,7 +135,7 @@ Stated plainly, because finding out by trying is a bad first impression.
 | **Scanned PDFs** | The text layer is read; a scan holds an image of words. That needs OCR, which the engine does not implement, and it says so rather than returning nothing. |
 | **Video transcoding** | Stream copy and remux only. A format change that requires re-encoding is refused as `option_not_supported`. |
 | **Playlist synchronization** | Content downloads a playlist; it does not keep a folder in step with one over time. |
-| **Deleting anything** | No tool removes an artifact, a job or a file. Retention is an operator concern (ADR 0023, proposed). |
+| **Deleting anything but your own upload** | `delete_upload` takes back bytes this server sent; nothing removes an artifact, a job, or a file in the library. Retention for those is an operator concern (ADR 0023, proposed). |
 | **Authentication on the engine** | The V1 API has none (ADR 0024). Keep it on a trusted network or behind a reverse proxy — this server inherits whatever reach it has. |
 
 ## What is coming
@@ -216,6 +217,33 @@ wrong one is the ordinary mistake.
 - The layering is enforced by tests: the MCP server may import `content_sdk`
   only — never an HTTP client, never backend internals
   (`tests/test_layering.py` at the repo root).
+
+## Where an uploaded file goes, and for how long
+
+A local path handed to `analyze_source` leaves this machine. The answer says
+so, rather than leaving it to documentation nobody opens at that moment:
+
+```json
+"upload": {
+  "upload_id": "upl_…",
+  "filename": "report.pdf",
+  "size_bytes": 1583,
+  "stored_on": "http://nas.local:8010",
+  "retention": "deleted 24h after last use",
+  "remove_with": "delete_upload"
+}
+```
+
+`stored_on` names the engine rather than a path, because the store is
+engine-owned and no path here would address it. `retention` is **read from the
+engine**, not assumed: the TTL is the operator's setting, and an engine too old
+to report it answers `unknown` rather than a comfortable guess — claiming "no
+expiry" when the default is 24h would be a falsehood in the reassuring
+direction. `get_config` carries the same policy up front, before anything is
+sent.
+
+The TTL runs from an upload's **last use**, not its creation, so retrying a job
+still finds its input.
 
 ## Local files, both directions
 

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -204,6 +204,16 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         return service.retry_job(client, job_id)
 
     @tool()
+    def delete_upload(upload_id: str) -> dict[str, Any]:
+        """Delete bytes uploaded from this machine, before the TTL expires.
+
+        `analyze_source` uploads a local file to the engine; the id it returns
+        under `upload` is what this takes. Removes only that upload — never an
+        artifact, never a file in the library.
+        """
+        return service.delete_upload(client, upload_id)
+
+    @tool()
     def get_config() -> dict[str, Any]:
         """Server-side context for building requests: credential ids for
         authenticated sources, whether delivery-by-default is on, and the

--- a/apps/mcp/content_mcp/service.py
+++ b/apps/mcp/content_mcp/service.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from content_sdk import ContentClient, outputs
+from content_sdk.errors import ContentError
 
 # get_artifact never streams large binaries over MCP (refinement 6): only small
 # text artifacts are inlined; everything else returns metadata + a reference.
@@ -108,24 +109,65 @@ def _source_for(client: ContentClient, source: str, credential: str | None):
     description says so plainly — an agent should choose it deliberately.
     """
     if _looks_like_url(source):
-        return outputs.url_source(source, credential_id=credential)
+        return outputs.url_source(source, credential_id=credential), None
     path = Path(source).expanduser()
     if not path.is_file():
         raise ValueError(
             f"'{source}' is neither a URL nor a file on this machine. "
             "Give a URL, or a path that exists where this MCP server runs."
         )
-    return client.upload_file(path)
+    record = client.upload(path)
+    upload_id = record.get("upload_id", "")
+    return (
+        outputs.upload_source(upload_id),
+        {
+            "upload_id": upload_id,
+            "filename": record.get("filename", path.name),
+            "size_bytes": record.get("size_bytes", 0),
+            # Where the bytes went, said plainly. A path would be a lie — the
+            # store is engine-owned and not addressable from here — so name the
+            # engine instead, which is the fact the caller actually needs.
+            "stored_on": client.base_url,
+            "retention": _retention(client),
+            "remove_with": "delete_upload",
+        },
+    )
+
+
+def _retention(client: ContentClient) -> str:
+    """How long the engine keeps an upload, in its own words.
+
+    Read from the engine rather than assumed: the TTL is the operator's
+    setting, and a number invented here would be a confident guess about
+    somebody else's machine.
+    """
+    try:
+        config = client.config() or {}
+    except ContentError:
+        return "unknown (the engine could not be asked)"
+    uploads = config.get("uploads")
+    if uploads is None:
+        # An engine older than this field. Saying "no TTL" here would be a
+        # confident falsehood in the reassuring direction — the default is 24h
+        # — and retention is the one thing not to guess about on somebody
+        # else's machine.
+        return "unknown (this engine does not report its upload policy)"
+    hours = uploads.get("ttl_hours")
+    if not hours:
+        return "kept until deleted (this engine has no expiry configured)"
+    when = "last use" if uploads.get("expire_from") == "last_use" else "upload"
+    return f"deleted {hours:g}h after {when}"
 
 
 def analyze_source(
     client: ContentClient, url: str, credential: str | None = None
 ) -> dict[str, Any]:
     """Analyze a URL **or a local file** and report what can be produced."""
-    analysis = client.analyze(_source_for(client, url, credential))
+    source, upload = _source_for(client, url, credential)
+    analysis = client.analyze(source)
     caps = client.get_capabilities(analysis.id)
     entry = analysis.sources[0]
-    return {
+    answer: dict[str, Any] = {
         "analysis_id": analysis.id,
         "resource_type": entry.resource_type,
         "title": entry.title,
@@ -134,6 +176,12 @@ def analyze_source(
             {"id": c.id, "status": c.status} for c in caps.sources[0].capabilities
         ],
     }
+    if upload is not None:
+        # A local file has left this machine. Say so in the answer the agent
+        # reads, rather than in documentation nobody opens at that moment:
+        # which engine holds it, how long, and how to take it back.
+        answer["upload"] = upload
+    return answer
 
 
 def list_capabilities(client: ContentClient, analysis_id: str) -> dict[str, Any]:
@@ -232,6 +280,20 @@ def retry_job(client: ContentClient, job_id: str) -> dict[str, Any]:
     return {"job_id": job.id, "status": job.status, "retry_of": job_id}
 
 
+def delete_upload(client: ContentClient, upload_id: str) -> dict[str, Any]:
+    """Remove bytes uploaded from this machine, now rather than on the TTL.
+
+    The counterpart of the upload that `analyze_source` performs silently: the
+    agent put a copy of someone's file on another machine, so the agent must be
+    able to take it back without waiting for a retention window.
+
+    It removes an upload — never an artifact, never a file in the library. A
+    job that still needs it will fail rather than read something else.
+    """
+    client.delete_upload(upload_id)
+    return {"upload_id": upload_id, "deleted": True}
+
+
 def get_config(client: ContentClient) -> dict[str, Any]:
     """What an agent needs to parameterize requests: the credential ids for
     authenticated sources, whether artifacts are delivered into the server
@@ -242,6 +304,10 @@ def get_config(client: ContentClient) -> dict[str, Any]:
         "delivery_by_default": config.get("delivery", {}).get("by_default", False),
         "folders": client.folders(),
         "language": config.get("language", {}),
+        # What happens to a local file handed to analyze_source: which engine
+        # receives it and how long it stays there. Part of the answer to "where
+        # did my file go", which should never require reading the docs.
+        "uploads": {**(config.get("uploads") or {}), "stored_on": client.base_url},
     }
 
 

--- a/apps/mcp/tests/test_service.py
+++ b/apps/mcp/tests/test_service.py
@@ -305,3 +305,42 @@ def test_retry_job_reruns_the_request_and_names_its_ancestor():
 
     assert seen == {"path": "/api/v1/jobs/job_old/retry", "method": "POST"}
     assert answer == {"job_id": "job_new", "status": "queued", "retry_of": "job_old"}
+
+
+# --- what happens to an uploaded file, said in the answer ------------------------
+
+
+def _engine(config: dict, *, uploads_ok: bool = True) -> ContentClient:
+    def handler(request):
+        path = request.url.path
+        if path.endswith("/config"):
+            return httpx.Response(200, json=config)
+        if path.endswith("/uploads"):
+            return httpx.Response(
+                201, json={"upload_id": "upl_1", "filename": "n.md", "size_bytes": 7}
+            )
+        return httpx.Response(200, json={})
+
+    return ContentClient(
+        "http://engine.example:8010",
+        http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+    )
+
+
+def test_retention_is_reported_from_what_the_engine_says():
+    client = _engine({"uploads": {"ttl_hours": 24, "expire_from": "last_use"}})
+    assert service._retention(client) == "deleted 24h after last use"
+
+
+def test_an_engine_that_does_not_report_its_policy_says_unknown():
+    """The dangerous case: an older engine returns no `uploads` block. Claiming
+    "no TTL" there would be a confident falsehood in the reassuring direction —
+    the default is in fact 24h — and retention is the one thing not to guess at
+    on somebody else's machine."""
+    assert "unknown" in service._retention(_engine({"credentials": []}))
+
+
+def test_an_engine_with_expiry_switched_off_says_so_plainly():
+    client = _engine({"uploads": {"ttl_hours": 0}})
+    answer = service._retention(client)
+    assert "no expiry" in answer and "unknown" not in answer


### PR DESCRIPTION
From a comment on the announcement:

> For a remote backend, I'd make upload location and retention explicit in every tool response. That is the part that gets sketchy once an agent can pull files off a laptop.

Correct, and it was not. `analyze_source` uploads a local file and returned an `analysis_id` and nothing else. The policy existed — engine-owned store, deliberately outside the allowed input roots that govern `file` sources, swept 24h after **last use** rather than creation — but only in documentation, at the exact moment nobody is reading documentation.

Three changes, one idea: **the answer carries the facts.**

- `GET /api/v1/config` reports the upload policy (TTL, whether it counts from last use, size and quota limits). Additive.
- `analyze_source` returns an `upload` block when the source was a local file: id, size, *which engine* holds it, retention, and the tool that removes it. `stored_on` names the engine rather than a path — the store is engine-owned and no path here would address it.
- `delete_upload`, the counterpart the server lacked. Removes an upload and only that: never an artifact, never a file in the library.

### The bug found by running it

Against the live 0.6.5 engine — which does not yet report the policy — the first version answered *"no TTL configured"*. The default is 24h. A confident falsehood in the reassuring direction is worse than no answer, so an engine that does not report now says `unknown`. Three cases pinned by tests.

Surface goes to 11 tools, and the README's "nothing deletes anything" becomes "nothing deletes anything but the bytes you sent".