### PR TITLE
stdio is a decision, and the README now says why

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,9 @@ rather than inferred:
 |  |  |
 | --- | --- |
 | **Works** | URLs and playlists · local files (uploaded to the engine, so a laptop can drive a NAS) · PDFs, read for their text layer · video, audio, subtitles, transcripts, summaries, translations, chapters, thumbnails, metadata, Markdown, PDF · delivery into your library · cookie-authenticated sources |
-| **Does not** | stdio only, no HTTP transport · no live progress (`get_job` is a poll) · no `.docx`/`.epub`/`.odt`/`.rtf`, no OCR for scans · no transcoding · no playlist sync · nothing deletes anything · [the API has no authentication](docs/architecture-decisions/0024-no-authentication-is-still-the-answer.md) |
+| **Does not** | no live progress (`get_job` is a poll) · no `.docx`/`.epub`/`.odt`/`.rtf`, no OCR for scans · no transcoding · no playlist sync · nothing deletes anything · [the API has no authentication](docs/architecture-decisions/0024-no-authentication-is-still-the-answer.md) |
 | **Needs a runner** | Summaries, translations and derived chapters want a local [Ollama](https://ollama.com) or a cloud key; transcripts want subtitles, or the optional Whisper runner. The engine reports these as `unavailable` up front rather than failing halfway |
+| **By design** | **stdio, not an HTTP endpoint** — the server runs where *you* do, which is what lets an agent hand it `~/Documents/report.pdf` and have the bytes uploaded to an engine on your NAS. It also means no open port on a system that has [no authentication](docs/architecture-decisions/0024-no-authentication-is-still-the-answer.md). For a client that cannot spawn a process — Open WebUI, hosted UIs — [`mcpo`](https://github.com/open-webui/mcpo) bridges it today |
 | **Coming** | [Retrying only what failed](docs/architecture-decisions/0025-retrying-only-what-failed.md) · [playlist sync](docs/roadmap/roadmap.md) · [retention](docs/architecture-decisions/0023-retention-and-reclaiming-disk.md) · more document readers |
 
 ### CLI — terminals, scripts, and cron

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -57,6 +57,46 @@ for air-gapped installs (`uv tool install ./content_mcp-<v>-py3-none-any.whl
 One environment variable: `CONTENT_API_URL` (default `http://localhost:8010`).
 The server speaks stdio — your MCP client spawns it; you never run it by hand.
 
+### Why stdio, and not an HTTP endpoint
+
+A deliberate choice rather than a missing feature, and the reason is the point
+of the whole project: **Content turns resources you already have into
+artifacts, and a lot of those live on your own machine.**
+
+Over stdio the server runs where you do. That is what makes this work:
+
+```text
+"Summarize ~/Documents/rapport.pdf"
+```
+
+The file is read on your machine and uploaded to the engine, which may be a NAS
+in another room. Move the server to an HTTP endpoint next to the engine and
+that sentence stops meaning anything — the path would resolve on the *server's*
+filesystem, so at best it fails, at worst it reads a different file with the
+same name. No amount of protocol design fixes that: the bytes are where the
+person is.
+
+Two things follow from it, both worth having:
+
+- **No network surface.** The engine has no authentication by design
+  ([ADR 0024](../../docs/architecture-decisions/0024-no-authentication-is-still-the-answer.md)),
+  and an HTTP MCP server would extend that to "anyone who can reach the port
+  can drive it — download, write files, spend your CPU". stdio has no port.
+- **No service to run.** The client starts and stops the process. Nothing to
+  supervise, nothing to restart, nothing left listening after you close the
+  laptop.
+
+**What stdio cannot do**, plainly: serve a client that cannot spawn a process on
+your machine — Open WebUI in a container, LibreChat, a hosted web UI. For those,
+[`mcpo`](https://github.com/open-webui/mcpo) bridges an stdio MCP server to
+HTTP/OpenAPI today, and Open WebUI documents it as its own path.
+
+An HTTP transport may still come as a **second mode** — the SDK does
+`streamable-http` with one parameter — for the inverse case: sources that are
+already remote, and a client that cannot spawn. It would ship bound to loopback
+by default, and it would have to refuse local paths outright rather than
+silently resolve them somewhere else. stdio stays the default either way.
+
 ### Claude Code
 
 ```bash
@@ -126,7 +166,6 @@ Stated plainly, because finding out by trying is a bad first impression.
 
 | Not available | Why, and what to do instead |
 | --- | --- |
-| **HTTP/SSE transport** | stdio only. Your client spawns the process; a remote server is not exposed. |
 | **MCP prompts** | Not provided. The tool descriptions and the server instructions carry the guidance instead. |
 | **Live progress** | `get_job` is a status poll. The engine has an event stream, but no MCP notification carries it — a long download is opaque until it ends. |
 | **Job logs** | Not exposed. `get_job` gives the failing step and its reason, which is what an agent can act on; the raw logs stay on the engine. |
@@ -153,8 +192,9 @@ implemented; each links to where the decision lives.
   ([ADR 0023](../../docs/architecture-decisions/0023-retention-and-reclaiming-disk.md),
   proposed).
 - **More document readers, and OCR** — the formats listed as refused above.
-- **HTTP transport** — stdio is what every client here speaks today; nothing
-  blocks the other one except a reason to build it.
+- **An HTTP transport as a second mode** — for clients that cannot spawn a
+  process (Open WebUI, hosted UIs). Not a replacement: see *Why stdio* above
+  for what it would cost, and `mcpo` for what works today.
 
 Something you need that is not here? The gap list is the roadmap's front door:
 [open an issue](https://github.com/LatentNoise/content/issues).


### PR DESCRIPTION
A comment on the announcement asked for an HTTP transport — *"more useful in general use; for OpenWebUI you'd need another layer"*. The suggestion is fair and the reader was right about OpenWebUI (it does native MCP over Streamable HTTP since v0.6.31).

What was wrong was **our** side: the README listed `stdio only, no HTTP transport` under *what it does not support*, so a considered choice read as a gap.

It is the opposite. Content turns resources you already have into artifacts, and a lot of those live on the machine the person is sitting at. Over stdio the server runs where they do — which is the only reason this means anything:

```
"Summarize ~/Documents/rapport.pdf"
```

The file is read locally and uploaded to an engine that may be a NAS in another room. Put the server behind an HTTP endpoint next to the engine and the sentence collapses: the path resolves on the *server's* filesystem, so it fails — or worse, reads a different file of the same name.

Two consequences worth keeping, now stated: stdio has **no port**, which matters on an engine that deliberately has no authentication (ADR 0024), and the client owns the process lifecycle, so there is no service to supervise.

And the honest half: stdio cannot serve a client that cannot spawn a process. [`mcpo`](https://github.com/open-webui/mcpo) bridges that today, and the README now says so instead of leaving the reader stuck. An HTTP transport stays possible as a **second mode** — the SDK does it with one parameter — bound to loopback and refusing local paths outright.

The gap list keeps only what is genuinely missing.