### PR TITLE
Version 0.6.6

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.5"
+    org.opencontainers.image.version="0.6.6"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.5"
+version = "0.6.6"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.5"
+version = "0.6.6"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.5"]
+dependencies = ["content-sdk==0.6.6"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.5", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.6", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.5"
+version = "0.6.6"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.5", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.6", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.5"
+version = "0.6.6"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.6.md
+++ b/docs/releases/v0.6.6.md
@@ -1,0 +1,86 @@
+Two answers to the announcement's first comments, and a PDF that states its
+title once.
+
+## An uploaded file says where it went and how long it stays
+
+> *"For a remote backend, I'd make upload location and retention explicit in
+> every tool response. That is the part that gets sketchy once an agent can
+> pull files off a laptop."*
+
+Correct, and it was not. `analyze_source` uploaded a local file and returned an
+`analysis_id` and nothing else. The policy existed — an engine-owned store,
+deliberately outside the allowed input roots that govern `file` sources, swept
+24 h after an upload's **last use** rather than its creation — but only in
+documentation, at the exact moment nobody reads documentation.
+
+Now the answer carries the facts:
+
+```json
+"upload": {
+  "upload_id": "upl_…", "filename": "report.pdf", "size_bytes": 1583,
+  "stored_on": "http://nas.local:8010",
+  "retention": "deleted 24h after last use",
+  "remove_with": "delete_upload"
+}
+```
+
+`GET /api/v1/config` reports the policy (TTL, whether it counts from last use,
+size and quota limits) so a client knows before sending, and **`delete_upload`**
+is the counterpart the server lacked: the agent put a copy of someone's file on
+another machine, so it can take it back without waiting for the window. It
+removes an upload and only that — never an artifact, never a file in the
+library.
+
+The retention string is read from the engine, never assumed. An engine too old
+to report its policy answers `unknown` rather than a comfortable guess: found
+by running it against a 0.6.5 engine, where the first version said "no TTL
+configured" while the default is in fact 24 h.
+
+## Why the MCP server speaks stdio
+
+> *"You should use http connection as it's more useful on general use."*
+
+Fair suggestion, and the README was answering it badly: `stdio only` sat under
+*what it does not support*, so a considered choice read as a gap.
+
+It is the opposite, and the reason is the point of the project. **Content turns
+resources you already have into artifacts, and many of those live on the
+machine you are sitting at.** Over stdio the server runs where you do, which is
+the only reason `"summarize ~/Documents/report.pdf"` means anything: the file is
+read locally and uploaded to an engine that may be a NAS in another room. Put
+the server behind an HTTP endpoint next to the engine and the sentence
+collapses — the path would resolve on the *server's* filesystem.
+
+Two consequences worth keeping: stdio has no port, which matters on an engine
+that deliberately has no authentication (ADR 0024), and the client owns the
+process lifecycle, so there is no service to supervise.
+
+The honest half is documented too: stdio cannot serve a client that cannot
+spawn a process — Open WebUI in a container, a hosted UI. `mcpo` bridges that
+today. An HTTP transport stays possible as a *second* mode, bound to loopback
+and refusing local paths outright.
+
+## A PDF states its title once, and looks like this decade
+
+A generated PDF showed its title twice. Not the renderer — neither backend
+draws the title into the body, and a one-heading document renders as one
+heading. The source carried it twice, which happens whenever something writes a
+header above a body that titles itself, and an LLM summary titles itself almost
+every time. The parser now collapses the narrow case: two headings, same level,
+same text, adjacent or separated by nothing but rules. The same title further
+down is left alone — a recurring section heading is a legitimate shape.
+
+The Typst template also gained an actual design: Libertinus for the body, one
+accent colour, a title over a hairline instead of a rule that repeats down the
+page, coloured list markers, italic quotes, code in a bordered rounded block,
+and a page number that starts at page two. Level-3 headings stop being grey,
+which read as *less* important than the list underneath.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+uv tool install --reinstall --refresh content-mcp   # or nothing, with uvx
+```
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.5...v0.6.6

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.5"
+version = "0.6.6"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships #44 (upload location and retention in every tool response, plus `delete_upload`), #45 (why stdio, documented as a decision rather than a gap) and #43 (PDF title stated once, modern typography).

Released rather than held because the first two answer comments on the announcement, and an answer that says "fixed on main" is worth less than one someone can install.