### PR TITLE
uvx caches; it does not follow PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,9 @@ exposes intention-level tools — not one per endpoint — to:
 
 The agent never needs shell access, yt-dlp syntax, or backend internals.
 
-**Nothing to install.** `uvx` fetches the server on first use and keeps it
-current, so the client owns the whole lifecycle:
+**Nothing to install.** `uvx` fetches the server on first use and caches it, so
+the client owns the whole lifecycle (updating stays explicit — `uvx --refresh`,
+or pin `content-mcp@x.y.z`):
 
 ```bash
 # Claude Code

--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -19,8 +19,8 @@ The server is an ordinary Python application — nothing to clone. There are two
 shapes, and which one you want depends on who should own the lifecycle.
 
 **Let the client fetch it (nothing installed).** `uvx` downloads the server on
-first use, caches it and keeps it current, so there is no step to forget and no
-version to upgrade by hand. This is the shortest path and the one to prefer:
+first use and caches it, so there is nothing to install and nothing left behind.
+This is the shortest path and the one to prefer:
 
 ```bash
 uvx content-mcp --version       # 0.6.4 — fetched on the spot
@@ -41,9 +41,19 @@ content-mcp --help
 pipx install content-mcp
 ```
 
-The trade-off is only who updates it: `uvx` follows PyPI, an installed tool
-stays where you put it until `uv tool upgrade content-mcp`. Both run the same
-wheel.
+**Either way, updating is explicit.** This is worth knowing, because it is easy
+to assume otherwise: `uvx` reuses the environment it cached and does *not*
+re-check PyPI on each run, so a server started this way keeps its version until
+you say otherwise. Measured, not assumed — a plain `uvx content-mcp` served
+0.6.5 the day 0.6.6 was published.
+
+```bash
+uvx --refresh content-mcp        # take the newest release
+uvx content-mcp@0.6.6            # or pin one, which a client config can do too
+uv tool upgrade content-mcp      # for the installed form
+```
+
+Both forms run the same wheel; the difference is only where it lives.
 
 [`content-mcp` on PyPI](https://pypi.org/project/content-mcp/) pulls
 [`content-sdk`](https://pypi.org/project/content-sdk/) as an ordinary


### PR DESCRIPTION
Yesterday's install rewrite claimed `uvx` *"keeps it current"* and *"follows PyPI"*.

Measured today, the day 0.6.6 was published:

| command | version served |
| --- | --- |
| `uvx content-mcp` | **0.6.5** |
| `uvx --refresh content-mcp` | 0.6.6 |
| `uvx content-mcp@0.6.6` | 0.6.6 |
| `uv pip install --no-cache content-mcp==0.6.6` | 0.6.6 |

uvx reuses the environment it cached and does not re-check the index per run. That is a comfortable falsehood on the install path we recommend: a reader would believe they were on the newest server while they were not, and would report a bug fixed two releases ago.

Both READMEs now state the caching plainly and give the three ways to move a version.

Second trap, named in the commit because it cost a wrong diagnosis: `uv venv` in /tmp picked Python 3.10.10 while content-mcp requires >=3.11, so the install failed as *"unsatisfiable"* and looked exactly like a PyPI propagation problem. It is the same failure `apps/mcp/release-check.sh` pins its interpreter to avoid.