### PR TITLE
yt-dlp 2026.08.19, and a watcher that says which thing happened

### DIFF
--- a/.github/scripts/ytdlp_base_check.py
+++ b/.github/scripts/ytdlp_base_check.py
@@ -108,6 +108,24 @@ def version_for(digest: str) -> str:
     return ""
 
 
+def issue_title(pinned_version: str, new_version: str, new_digest: str) -> str:
+    """Say which of the two very different things happened.
+
+    A moving digest is worth watching either way, but the first version of this
+    title reported both as "X available (pinned: X)" — which, when the tag had
+    merely been rebuilt, read as a bug in the checker and buried the case that
+    actually matters. yt-dlp going stale is what breaks YouTube downloads; a
+    rebuilt base is usually distro patches.
+    """
+    if not new_version:
+        return (
+            f"yt-dlp base image: untagged {new_digest[:19]} (pinned: {pinned_version})"
+        )
+    if new_version == pinned_version:
+        return f"yt-dlp base image rebuilt: {new_version} republished, same yt-dlp"
+    return f"yt-dlp {new_version} available (pinned: {pinned_version})"
+
+
 def issue_body(pinned_version, pinned_digest, new_version, new_digest) -> str:
     named = new_version or "(untagged — compare by digest)"
     release = (
@@ -116,9 +134,26 @@ def issue_body(pinned_version, pinned_digest, new_version, new_digest) -> str:
         else "_no matching version tag found; check "
         "https://github.com/yt-dlp/yt-dlp/releases_"
     )
+    if new_version and new_version == pinned_version:
+        headline = (
+            f"`{IMAGE}:{new_version}` has been **rebuilt**: same yt-dlp, new "
+            "image. Typically distro patches in the base layers — worth taking, "
+            "rarely urgent."
+        )
+    elif new_version:
+        headline = (
+            f"**yt-dlp {new_version}** is out; the pin is still "
+            f"`{pinned_version}`. This is the one that matters: a stale yt-dlp "
+            "is how YouTube downloads start failing."
+        )
+    else:
+        headline = (
+            f"A newer `{IMAGE}` base image is available, with no version tag "
+            "matching its digest."
+        )
     return f"""\
-A newer `{IMAGE}` base image is available. **Nothing has been changed** — this
-issue is a notification, and the bump is a deliberate, validated act.
+{headline} **Nothing has been changed** — this issue is a notification, and the
+bump is a deliberate, validated act.
 
 | | Pinned now | Available |
 | --- | --- | --- |
@@ -184,10 +219,7 @@ def main() -> None:
                 issue_body(pinned_version, pinned_digest, new_version, new_digest)
             )
 
-    title = (
-        f"yt-dlp base image: {new_version or new_digest[:19]} available "
-        f"(pinned: {pinned_version})"
-    )
+    title = issue_title(pinned_version, new_version, new_digest)
     output = os.getenv("GITHUB_OUTPUT")
     if output:
         with open(output, "a", encoding="utf-8") as handle:

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -14,8 +14,8 @@
 # Bumping it is a deliberate, validated act: see
 # docs/operations/ytdlp-base-image.md. A scheduled workflow files an issue when
 # a newer upstream image appears; it never edits this file.
-ARG YTDLP_BASE_VERSION=2026.07.04
-ARG YTDLP_BASE_DIGEST=sha256:daef12c6ed97b6b2984d81142ddb0c56ee2f81e2d7372aba0ecd4fa7b5709889
+ARG YTDLP_BASE_VERSION=2026.08.19
+ARG YTDLP_BASE_DIGEST=sha256:11c9231bd209580b25e81daad39b3bbbd06c31443d0f9dab2c196e90c6e76156
 FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}
 
 # Re-declared: an ARG consumed by FROM is out of scope in the build stage.

--- a/tests/test_ytdlp_base_check.py
+++ b/tests/test_ytdlp_base_check.py
@@ -1,0 +1,51 @@
+"""The base-image watcher must say which of two things happened.
+
+Issue #28 was titled `yt-dlp base image: 2026.07.04 available (pinned:
+2026.07.04)`. The detection was right — the tag had been rebuilt and the digest
+moved, which is exactly why the pin carries a digest — but the title read as a
+broken checker, and it looked identical to the case that actually matters.
+
+They are not the same thing. A new yt-dlp version is how YouTube downloads stop
+working; a rebuilt base is usually distro patches. A watcher whose alerts all
+look alike trains its reader to ignore them.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / ".github/scripts"))
+
+from ytdlp_base_check import issue_body, issue_title
+
+DIGEST = "sha256:9587e8c5a54b1b8539e744747798c16b217cb35410abf4f239a7b6f1f09542ae"
+
+
+def test_a_new_version_leads_with_the_version():
+    title = issue_title("2026.07.04", "2026.08.19", DIGEST)
+    assert title == "yt-dlp 2026.08.19 available (pinned: 2026.07.04)"
+
+
+def test_a_rebuild_says_rebuilt_rather_than_repeating_the_version():
+    """The #28 case: same version either side, and the old title said so twice."""
+    title = issue_title("2026.07.04", "2026.07.04", DIGEST)
+    assert "rebuilt" in title
+    assert "available (pinned: 2026.07.04)" not in title
+
+
+def test_an_untagged_digest_is_named_as_such():
+    title = issue_title("2026.07.04", "", DIGEST)
+    assert "untagged" in title and DIGEST[:19] in title
+
+
+def test_the_body_opens_on_the_distinction_too():
+    """A reader who only skims the first line still learns which case it is."""
+    upgrade = issue_body("2026.07.04", "sha256:old", "2026.08.19", DIGEST)
+    rebuild = issue_body("2026.07.04", "sha256:old", "2026.07.04", DIGEST)
+
+    assert "is out" in upgrade and "stale yt-dlp" in upgrade
+    assert "rebuilt" in rebuild and "rarely urgent" in rebuild
+    # Both keep the promise the workflow makes: it never edits anything.
+    for body in (upgrade, rebuild):
+        assert "Nothing has been changed" in body


### PR DESCRIPTION
Issue #28 read `yt-dlp base image: 2026.07.04 available (pinned: 2026.07.04)` — the same version on both sides, which reads like a broken checker.

**It is not broken.** The tag had been *rebuilt*: same yt-dlp, new digest. That is exactly why the pin carries a digest and not just a version, so the detection was right.

The title was the problem, because it made two very different cases look identical — and while looking into it, the check turned up the case that was hiding behind the noise: **2026.08.19 has been out for weeks** while the pin sat on 2026.07.04. An alert that cries wolf buries the real one.

### Both halves

**The watcher** now says which happened, in the title and in the body's first line:

| Situation | Title |
| --- | --- |
| New version | `yt-dlp 2026.08.19 available (pinned: 2026.07.04)` |
| Rebuilt tag | `yt-dlp base image rebuilt: 2026.07.04 republished, same yt-dlp` |
| No version tag | `yt-dlp base image: untagged sha256:… (pinned: …)` |

`tests/test_ytdlp_base_check.py` pins all three.

**The pin** moves to 2026.08.19, digest `sha256:11c9231b…` — taken from the *version tag*, not from `latest`, so the two cannot drift apart.

### Validated as docs/operations/ytdlp-base-image.md requires

- image builds on the new base
- `yt-dlp --version` inside it → **2026.08.19**
- `create_app()` still constructs (the 0.6.4 boot guard)
- typst 0.15.1 and ffmpeg 8.1.2 survive the new base
- a real YouTube download through it → 9.7 MB
- `make validate` green
- release-marked checks **7/7**, including the anti-staleness canary asserting `video.download` stays available for a known-good video, and the real-LLM summary