### PR TITLE
Version 0.6.7

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.6"
+    org.opencontainers.image.version="0.6.7"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.6"
+version = "0.6.7"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.6"
+version = "0.6.7"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.6"]
+dependencies = ["content-sdk==0.6.7"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -108,7 +108,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.6", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.7", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.6"
+version = "0.6.7"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.6", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.7", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.6"
+version = "0.6.7"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.7.md
+++ b/docs/releases/v0.6.7.md
@@ -1,0 +1,60 @@
+The engine downloads with **yt-dlp 2026.08.19**, seven weeks newer than the
+version 0.6.6 shipped with.
+
+## Why this one matters
+
+yt-dlp is the dependency that rots on its own: YouTube changes, and a yt-dlp
+that has not moved stops working — usually not with a clear error, but with
+"Requested format is not available" or a refusal that looks like something
+else. The pin sat on `2026.07.04` while `2026.08.19` had been out for weeks.
+
+If you download from YouTube, take this release.
+
+## How it went unnoticed, and the fix for that
+
+A scheduled job watches the base image and files an issue when upstream moves.
+It had filed one, titled:
+
+```text
+yt-dlp base image: 2026.07.04 available (pinned: 2026.07.04)
+```
+
+The same version on both sides, which reads like a broken checker. It was not:
+the tag had been *rebuilt* — same yt-dlp, new digest — which is exactly why the
+pin carries a digest and not just a version. But the title made a routine
+rebuild indistinguishable from a real version bump, so the alert that mattered
+looked like the noise, and the noise is what everyone learns to skip.
+
+The watcher now says which of the three things happened:
+
+| Situation | Title |
+| --- | --- |
+| New version | `yt-dlp 2026.08.19 available (pinned: 2026.07.04)` |
+| Rebuilt tag | `yt-dlp base image rebuilt: 2026.07.04 republished, same yt-dlp` |
+| Digest with no version tag | `yt-dlp base image: untagged sha256:… (pinned: …)` |
+
+The body opens on the same distinction, and three tests pin the wordings. The
+new pin also takes its digest from the **version tag** rather than from
+`latest`, so the two cannot drift apart.
+
+## Validated before shipping
+
+Per `docs/operations/ytdlp-base-image.md`, on the real image rather than from
+reading the diff: it builds on the new base; `yt-dlp --version` inside answers
+`2026.08.19`; `create_app()` still constructs (the boot guard added in 0.6.4);
+Typst 0.15.1 and ffmpeg 8.1.2 survive the new base; a real YouTube download
+lands 9.7 MB through it; `make validate` is green; and the release-marked
+checks pass 7/7 — including the canary that asserts `video.download` stays
+available for a known-good video, which is the check that would have caught a
+stale yt-dlp on its own.
+
+## Upgrading
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+The Python packages are unchanged in substance this release; the engine image
+is the one that moved.
+
+**Full changelog**: https://github.com/LatentNoise/content/compare/v0.6.6...v0.6.7

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.6"
+__version__ = "0.6.7"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.6"
+version = "0.6.7"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Ships #48: the engine downloads with **yt-dlp 2026.08.19**, seven weeks newer than what 0.6.6 carried.

yt-dlp is the dependency that rots on its own — a stale one stops working against YouTube, usually with an error that points somewhere else. The pin sat on `2026.07.04` because the watcher's alert for a *rebuilt* tag was worded exactly like its alert for a *new version*, so the one that mattered read as noise. Both the pin and the wording are fixed.

Validated on the real image, not from the diff: builds on the new base, `yt-dlp --version` → 2026.08.19, `create_app()` still constructs, typst and ffmpeg survive, a real YouTube download lands 9.7 MB, `make validate` green, release checks 7/7.