### PR TITLE
Ask Ollama for a window that fits, instead of hoping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ CONTENT_ALLOW_PRIVATE_NETWORKS=false
 # Ollama daemon as seen from the container; empty model = first installed.
 CONTENT_OLLAMA_URL=http://host.docker.internal:11434
 CONTENT_OLLAMA_MODEL=
+# Context window ceiling asked of Ollama. 32768 covers roughly 2 h 20 of
+# speech in one summary; past its window Ollama keeps half of it, so a
+# slightly-too-long transcript loses more than half. Raise it (and give
+# Ollama the RAM) for longer recordings; 0 = let the daemon decide.
+CONTENT_OLLAMA_MAX_CONTEXT=32768
 # Cloud summarizers (secrets — leave empty to disable).
 CONTENT_ANTHROPIC_API_KEY=
 CONTENT_OPENAI_API_KEY=

--- a/apps/backend/content/api/app.py
+++ b/apps/backend/content/api/app.py
@@ -276,7 +276,13 @@ def create_app(
     settings = settings or settings_from_env()
     store = store or Store(settings.db_path)
     if providers is None:
-        summarizers: list = [OllamaProvider(settings.ollama_url, settings.ollama_model)]
+        summarizers: list = [
+            OllamaProvider(
+                settings.ollama_url,
+                settings.ollama_model,
+                settings.ollama_max_context,
+            )
+        ]
         if settings.anthropic_api_key:
             summarizers.append(
                 CloudSummarizer(

--- a/apps/backend/content/application/collections.py
+++ b/apps/backend/content/application/collections.py
@@ -208,6 +208,11 @@ class CollectionMemberRunner:
                     input_materials=inputs,
                     cancel_check=ctx.cancel_check,
                     on_progress=ctx.on_progress,
+                    # A member's step warns like any other. Forgetting this
+                    # line does not break anything visibly: the default is a
+                    # no-op, so a truncated summary of episode 7 of a playlist
+                    # would simply come back looking clean.
+                    on_warning=ctx.on_warning,
                 ),
             )
             materials[member_step.id] = [

--- a/apps/backend/content/config.py
+++ b/apps/backend/content/config.py
@@ -68,6 +68,13 @@ class ContentSettings:
     allowed_input_roots: tuple[Path, ...] = field(default_factory=tuple)
     ollama_url: str = "http://localhost:11434"
     ollama_model: str = ""  # empty = first installed model (deterministic)
+    # Ceiling on the context window the engine asks Ollama for. The window is
+    # sized per request from the prompt; this bounds it, because the memory is
+    # the daemon's and the engine cannot see how much of it there is. 0 leaves
+    # the choice to the daemon entirely (the pre-0.6.8 behaviour). Raising it
+    # extends how long a recording can be summarised whole — at the cost of RAM
+    # on the machine running Ollama.
+    ollama_max_context: int = 32768
     # Speech-to-text (audio.transcribe) model, used when the optional [stt]
     # extra (faster-whisper) is installed. Absent extra = variants unavailable.
     whisper_model: str = "small"
@@ -530,6 +537,7 @@ def settings_from_env() -> ContentSettings:
         allowed_input_roots=roots,
         ollama_url=os.getenv("CONTENT_OLLAMA_URL", "http://localhost:11434"),
         ollama_model=os.getenv("CONTENT_OLLAMA_MODEL", ""),
+        ollama_max_context=_to_int(os.getenv("CONTENT_OLLAMA_MAX_CONTEXT"), 32768),
         whisper_model=os.getenv("CONTENT_WHISPER_MODEL", "small"),
         pdf_renderer=os.getenv("CONTENT_PDF_RENDERER", "auto").strip().lower(),
         typst_binary=os.getenv("CONTENT_TYPST_BINARY", "typst"),

--- a/apps/backend/content/providers/ollama.py
+++ b/apps/backend/content/providers/ollama.py
@@ -43,6 +43,43 @@ _AVAILABILITY_TTL_SECONDS = 30.0
 # the acceptable failure here; crying wolf is not.
 _CHARS_PER_TOKEN_FLOOR = 8
 
+# The other direction, used to *size* the window rather than to judge it. French
+# prose measured at 3.77 characters per token on this corpus; 3 over-asks by
+# about a quarter, which costs a little memory and buys the margin. Denser
+# scripts tokenise closer to 1 character per token and will still overflow —
+# `_warn_if_truncated` remains the backstop, by design.
+_CHARS_PER_TOKEN_DENSE = 3
+
+# Room for the answer inside the same window.
+_OUTPUT_HEADROOM_TOKENS = 2048
+
+# Below this, asking for a smaller window than the daemon would have used gains
+# nothing and risks clipping a short prompt.
+_MIN_CONTEXT_TOKENS = 4096
+
+
+def _context_for(prompt: str, ceiling: int) -> int | None:
+    """The window to ask for, or None to leave the choice to the daemon.
+
+    Ollama does not refuse a prompt that does not fit — it truncates it, and it
+    does so on a cliff. Measured on gemma3:4b against a 32 768-token window: a
+    27 304-token prompt was read whole, and a 33 363-token one was read as
+    16 387 — *half* the window, not the window. Two percent over the line costs
+    fifty percent of the source. The same halving reproduced at a requested
+    window of 49 152, where a 50 319-token prompt came back as 24 579.
+
+    So the window is not something to hope about. The daemon's default is one
+    global number chosen with no knowledge of the prompt — and when
+    `OLLAMA_CONTEXT_LENGTH` is unset entirely, that number is 4 096, which
+    halves the transcript of a twenty-minute video. Asking per request is both
+    more correct and cheaper: a short summary no longer reserves a window sized
+    for the longest job the operator once anticipated.
+    """
+    if ceiling <= 0:
+        return None  # explicitly disabled: whatever the daemon decides
+    need = len(prompt) // _CHARS_PER_TOKEN_DENSE + _OUTPUT_HEADROOM_TOKENS
+    return max(_MIN_CONTEXT_TOKENS, min(need, ceiling))
+
 
 def _warn_if_truncated(prompt, payload, model, ctx) -> None:
     """Say so when the daemon read less of the prompt than we sent it.
@@ -73,7 +110,8 @@ def _warn_if_truncated(prompt, payload, model, ctx) -> None:
             f"The model read {read} tokens of a prompt of at least ~{floor}: "
             f"at most {kept}% of the source reached it, and the rest was "
             "silently dropped by the context window. Raise "
-            "OLLAMA_CONTEXT_LENGTH on the daemon, or send a shorter source."
+            "CONTENT_OLLAMA_MAX_CONTEXT (and give the daemon the memory for "
+            "it), or send a shorter source."
         ),
         {
             "provider": "ollama",
@@ -89,9 +127,15 @@ class OllamaProvider:
     location = "local"
     operations = ("text.summarize", "text.translate", "chapters.derive")
 
-    def __init__(self, base_url: str = "http://localhost:11434", model: str = ""):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "",
+        max_context: int = 32768,
+    ):
         self.base_url = base_url.rstrip("/")
         self.configured_model = model
+        self.max_context = max_context
         self.tool_version = ""
         self._probe_cache: tuple[float, bool] | None = None
         self._models_cache: tuple[float, list[str]] | None = None
@@ -217,12 +261,16 @@ class OllamaProvider:
         # Blocking single call, bounded by the step timeout. Cooperative
         # cancellation cannot interrupt it mid-call (documented limitation of
         # service runners); the job cancels right after the call returns.
+        options: dict = {"temperature": 0.2}
+        window = _context_for(prompt, self.max_context)
+        if window is not None:
+            options["num_ctx"] = window
         body = json.dumps(
             {
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
-                "options": {"temperature": 0.2},
+                "options": options,
             }
         ).encode()
         request = urllib.request.Request(

--- a/apps/backend/tests/test_llm_truncation.py
+++ b/apps/backend/tests/test_llm_truncation.py
@@ -18,7 +18,7 @@ prose runs nearer 4), so it can miss a truncation but can never invent one.
 
 from __future__ import annotations
 
-from content.providers.ollama import _warn_if_truncated
+from content.providers.ollama import _context_for, _warn_if_truncated
 
 
 class _Ctx:
@@ -44,8 +44,9 @@ def test_a_truncated_prompt_is_reported():
     assert "16387" in message and "silently" in message
     assert details["prompt_eval_count"] == 16_387
     assert details["prompt_tokens_at_least"] == 24_500
-    # The remedy is named, since the ceiling is the daemon's, not the engine's.
-    assert "OLLAMA_CONTEXT_LENGTH" in message
+    # The remedy is named — and it is the engine's own setting, since the engine
+    # now asks for the window rather than inheriting the daemon's.
+    assert "CONTENT_OLLAMA_MAX_CONTEXT" in message
 
 
 def test_a_prompt_that_fitted_says_nothing():
@@ -216,3 +217,71 @@ def test_a_warning_does_not_leak_into_the_next_job(store, settings, providers):
 
     assert store.list_artifacts(noisy)[0]["provenance"]["warnings"] != []
     assert store.list_artifacts(quiet)[0]["provenance"]["warnings"] == []
+
+
+# --- asking for a window that fits, instead of hoping ---------------------------
+#
+# Measured on gemma3:4b, Ollama 0.32, against a 32 768-token window:
+#
+#     prompt 27 304 tokens -> read 27 304   (whole)
+#     prompt 33 363 tokens -> read 16 387   (half the window, plus scaffolding)
+#
+# and again at a requested window of 49 152:
+#
+#     prompt 50 319 tokens -> read 24 579   (half the window, plus scaffolding)
+#
+# Ollama does not degrade gracefully past its window: it keeps half of it. Two
+# percent over the line costs fifty percent of the source, which is why the
+# engine now sizes the window from the prompt rather than inheriting whatever
+# single global number the daemon was started with.
+
+
+def test_a_short_prompt_does_not_reserve_a_long_window():
+    """The cheap direction of the same change: a two-page summary no longer
+    reserves a window sized for the longest job the operator once anticipated."""
+    assert _context_for("x" * 1_000, 32_768) == 4_096
+
+
+def test_the_window_grows_with_the_prompt():
+    # 60 000 characters of prose is ~16 000 tokens; asking for 22 048 clears it
+    # with the margin the 3-characters-per-token estimate is chosen to give.
+    assert _context_for("x" * 60_000, 32_768) == 22_048
+
+
+def test_a_two_hour_transcript_fits_under_the_default_ceiling():
+    """The case the maintainer asked about. ~18 000 words of French speech is
+    about 104 000 characters, measured at 27 400 tokens — under the 32 768
+    default, so it is summarised whole rather than halved."""
+    assert _context_for("x" * 104_000, 32_768) == 32_768
+    # and the estimate is not what limits it: the true need is below the cap
+    assert 104_000 // 3 + 2_048 > 27_400
+
+
+def test_the_ceiling_is_a_ceiling():
+    """Beyond it the engine stops asking for more, and `_warn_if_truncated`
+    becomes the honest answer instead."""
+    assert _context_for("x" * 5_000_000, 32_768) == 32_768
+
+
+def test_zero_hands_the_choice_back_to_the_daemon():
+    """The pre-0.6.8 behaviour, kept reachable: an operator who has tuned
+    OLLAMA_CONTEXT_LENGTH themselves does not want it second-guessed."""
+    assert _context_for("x" * 500_000, 0) is None
+
+
+def test_a_member_of_a_collection_warns_like_any_other_step():
+    """A playlist member runs under its own ExecutionContext, built by
+    `application/collections.py` rather than by the executor. That context
+    forwards `cancel_check` and `on_progress`; when it did not also forward
+    `on_warning`, a truncated summary of episode 7 came back looking clean —
+    the default is a no-op, so nothing failed and nothing was reported."""
+    import inspect
+
+    from content.application import collections
+
+    source = inspect.getsource(collections)
+    built = source.count("ExecutionContext(")
+    forwarded = source.count("on_warning=ctx.on_warning")
+    assert built and forwarded == built, (
+        f"{built} ExecutionContext(s) built here, {forwarded} forward on_warning"
+    )

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - CONTENT_OPENAI_MODEL=${CONTENT_OPENAI_MODEL:-gpt-4o-mini}
       - CONTENT_OLLAMA_URL=${CONTENT_OLLAMA_URL:-http://host.docker.internal:11434}
       - CONTENT_OLLAMA_MODEL=${CONTENT_OLLAMA_MODEL:-}
+      - CONTENT_OLLAMA_MAX_CONTEXT=${CONTENT_OLLAMA_MAX_CONTEXT:-32768}
       # Speech-to-text model (only used when the image was built with
       # INSTALL_STT=true; see build args above).
       - CONTENT_WHISPER_MODEL=${CONTENT_WHISPER_MODEL:-small}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - CONTENT_OPENAI_MODEL=${CONTENT_OPENAI_MODEL:-gpt-4o-mini}
       - CONTENT_OLLAMA_URL=${CONTENT_OLLAMA_URL:-http://host.docker.internal:11434}
       - CONTENT_OLLAMA_MODEL=${CONTENT_OLLAMA_MODEL:-}
+      - CONTENT_OLLAMA_MAX_CONTEXT=${CONTENT_OLLAMA_MAX_CONTEXT:-32768}
       # Speech-to-text model (only used when the image was built with
       # INSTALL_STT=true; see build args above).
       - CONTENT_WHISPER_MODEL=${CONTENT_WHISPER_MODEL:-small}

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -157,6 +157,7 @@ is in [HomeTube's README](../../apps/web-hometube/README.md#language-preferences
 | **🧠 Providers & LLM runners** | | |
 | `CONTENT_YTDLP_EXTRA_ARGS` | — | The operator's yt-dlp args (trusted), added to every call |
 | `CONTENT_OLLAMA_URL` / `_MODEL` | host / auto | The **local** LLM for `summary`, `translation` and derived `chapters`. Empty model = the first installed one, resolved deterministically and recorded in provenance |
+| `CONTENT_OLLAMA_MAX_CONTEXT` | `32768` | Ceiling on the context window the engine asks Ollama for. The window is sized per request from the prompt; this bounds it, because the memory is the daemon's. Ollama does not degrade gracefully past its window — it keeps **half** of it, so a prompt 2% too long loses 50% of the source. Raising this extends how long a recording can be summarised whole, at the cost of RAM where Ollama runs. `0` hands the choice back to the daemon |
 | `CONTENT_WHISPER_MODEL` | `small` | The speech-to-text model (requires the `[stt]` extra / an image built with `INSTALL_STT=true`) — activates transcript/summary **from audio** |
 | `CONTENT_ANTHROPIC_API_KEY` / `_MODEL` | — / `claude-sonnet-5` | The Anthropic **cloud** LLM for `summary`, `translation` and `chapters` (a key = active; excluded if `privacy.allow_cloud_providers:false`) |
 | `CONTENT_OPENAI_API_KEY` / `_MODEL` | — / `gpt-4o-mini` | The OpenAI **cloud** LLM, same three operations |


### PR DESCRIPTION
Follow-up to #50. Saying *"this summary covers half your transcript"* was the honest half of the job; this is the other half.

## What was actually happening

Ollama does not degrade gracefully past its context window — **it keeps exactly half of it.** Measured on gemma3:4b against a 32 768-token window:

| prompt | read |
| --- | --- |
| 27 304 tokens | **27 304** — whole |
| 33 363 tokens | **16 387** — half the window |
| 50 319 tokens (window raised to 49 152) | **24 579** — half again |

Two percent over the line costs fifty percent of the source. A cliff, not a slope — which is why the failure looked so arbitrary from outside.

And Content sent no `num_ctx` at all, so the window was whatever single global number the daemon happened to be started with. When `OLLAMA_CONTEXT_LENGTH` is unset, that number is **4096**, which halves the transcript of a twenty-minute video on a stock install.

## The change

The engine sizes the window per request from the prompt, bounded by a new `CONTENT_OLLAMA_MAX_CONTEXT` (default `32768`). Sizing *down* matters as much as up: a two-page summary no longer reserves a window meant for the longest job the operator once anticipated. `0` hands the choice back to the daemon for anyone who has tuned it themselves.

**Verified end to end, not only in tests:** the 33 029-word transcript that was being halved is read whole with the ceiling at 65536 — no warning, and the marker planted in its final line reaches the summary.

## A hole the warning shipped with

A collection member runs under an `ExecutionContext` built in `application/collections.py`, not by the executor — and that one forwarded `cancel_check` and `on_progress` but **not** `on_warning`. Nothing broke visibly, because the default is a no-op: a truncated summary of episode 7 of a playlist simply came back looking clean. Fixed, with a test that pins *every* `ExecutionContext` built there rather than today's one.

## One recorded, not fixed

A reused artifact would not carry its warnings — `_find_reusable` copies `attributes` and `producer` but not `warnings`, so a cached truncated summary would be served as clean. Unreachable while `cache_enabled` is False (ADR 0009), so it went to `work/discoveries.md` instead: building for a disabled feature is the abstraction AGENTS.md asks us not to add. Whoever turns the cache on owns it.

797 backend tests, `make validate` green.