### PR TITLE
The README opens with a picture of the architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@
 !.github/workflows/*.yml
 !.github/dependabot.yml
 
+# The README's architecture diagram, generated as one file per colour
+# scheme (scripts/gen_readme_diagram.py). SVG is text, so it belongs in
+# this allowlist; binary media stays out and is attached to releases.
+!docs/assets/*.svg
+
 !apps/web-hometube/.streamlit/config.toml
 !apps/web-studio/.streamlit/config.toml
 !apps/web-admin/.streamlit/config.toml

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ VERSION_MODULES    := apps/backend/content/__init__.py \
 .DEFAULT_GOAL := validate
 .PHONY: help install hooks format lint test test-all ui-venv test-ui test-ui-live \
         validate validate-all validate-release clean run \
-        version version-update version-tag wheels deploy-compose extension-zip docker-up docker-update docker-down \
+        version version-update version-tag wheels deploy-compose readme-diagram extension-zip docker-up docker-update docker-down \
         docker-logs cookies
 
 help:  ## List the available targets
@@ -251,6 +251,13 @@ wheels:  ## Build the SDK + CLI + MCP wheels for a release (dist/)
 # the two can never describe different deployments (tests/test_deploy_compose).
 deploy-compose:  ## Regenerate deploy/docker-compose.yml from docker-compose.yml
 	$(VENV)/python scripts/gen_deploy_compose.py
+
+# The README opens with a diagram, and GitHub needs one file per colour
+# scheme to follow its own theme. Both come from one geometry so a client
+# added to the row cannot appear in only one of them
+# (tests/test_readme_diagram).
+readme-diagram:  ## Regenerate the README's architecture SVGs (light + dark)
+	$(VENV)/python scripts/gen_readme_diagram.py
 
 # --- browser extension -----------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@
 [Connect an agent](#mcp-server--for-agents-and-ides) ·
 [Read the docs](docs/README.md)
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/architecture-dark.svg">
+  <img src="docs/assets/architecture-light.svg" width="100%"
+       alt="Sources — a URL, a file, or text — enter one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Out come video, audio, subtitles, transcript, summary, translation, chapters and PDF.">
+</picture>
+
 </div>
 
 Content is a self-hosted engine that turns supported sources into media,

--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 476" width="960" height="476" font-family="ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,Helvetica,Arial,sans-serif" role="img" aria-labelledby="title desc">
+  <title id="title">Content's architecture</title>
+  <desc id="desc">Sources — a URL, a file, or text — enter one self-hosted engine that analyzes, plans, runs and delivers. Every client (HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the SDK and the REST API) sits above the engine and reaches it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#30363d"/>
+    </marker>
+  </defs>
+  <text x="480.0" y="22.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">CLIENTS</text>
+  <rect x="40.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="90.6" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">HomeTube</text>
+  <rect x="151.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="201.9" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Studio</text>
+  <rect x="262.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="313.1" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Console</text>
+  <rect x="373.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="424.4" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Extension</text>
+  <rect x="485.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="535.6" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">MCP server</text>
+  <rect x="596.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="646.9" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">CLI</text>
+  <rect x="707.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="758.1" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Python SDK</text>
+  <rect x="818.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="869.4" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">REST API</text>
+  <path d="M 90.6 72.0 L 90.6 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 201.9 72.0 L 201.9 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 313.1 72.0 L 313.1 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 424.4 72.0 L 424.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 535.6 72.0 L 535.6 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 646.9 72.0 L 646.9 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 758.1 72.0 L 758.1 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 869.4 72.0 L 869.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 90.6 92.0 L 869.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 480.0 92.0 L 480.0 146.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <text x="492.0" y="122.0" fill="#8b949e" font-size="11" text-anchor="start">one public contract</text>
+  <text x="125.0" y="158.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">SOURCES</text>
+  <rect x="60.0" y="174.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="125.0" y="189.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a URL</text>
+  <rect x="60.0" y="212.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="125.0" y="227.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a file</text>
+  <rect x="60.0" y="250.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
+  <text x="125.0" y="265.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">text</text>
+  <path d="M 190.0 189.0 L 208.0 189.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 190.0 227.0 L 208.0 227.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 190.0 265.0 L 208.0 265.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 208.0 189.0 L 208.0 265.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 208.0 227.0 L 244.0 227.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <rect x="250" y="152" width="460" height="150" rx="14" fill="#1f6feb" stroke="#1f6feb"/>
+  <text x="480.0" y="186" fill="#ffffff" font-size="20" font-weight="650" text-anchor="middle">Content engine</text>
+  <text x="480.0" y="208.0" fill="#cddffb" font-size="11.5" text-anchor="middle">self-hosted · the only business logic</text>
+  <rect x="274.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="321.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">analyze</text>
+  <rect x="380.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="427.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">plan</text>
+  <rect x="486.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="533.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">run</text>
+  <rect x="592.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="639.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">deliver</text>
+  <path d="M 480.0 302.0 L 480.0 352.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <text x="492.0" y="328.0" fill="#8b949e" font-size="11" text-anchor="start">delivered where you want them</text>
+  <text x="480.0" y="368.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">ARTIFACTS</text>
+  <rect x="40.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="90.6" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">video</text>
+  <rect x="151.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="201.9" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">audio</text>
+  <rect x="262.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="313.1" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">subtitles</text>
+  <rect x="373.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="424.4" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">transcript</text>
+  <rect x="485.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="535.6" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">summary</text>
+  <rect x="596.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="646.9" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">translation</text>
+  <rect x="707.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="758.1" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">chapters</text>
+  <rect x="818.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
+  <text x="869.4" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">PDF</text>
+  <text x="480.0" y="436.0" fill="#8b949e" font-size="11" text-anchor="middle">…and metadata, images, Markdown, keyframes</text>
+</svg>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 476" width="960" height="476" font-family="ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,Helvetica,Arial,sans-serif" role="img" aria-labelledby="title desc">
+  <title id="title">Content's architecture</title>
+  <desc id="desc">Sources — a URL, a file, or text — enter one self-hosted engine that analyzes, plans, runs and delivers. Every client (HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the SDK and the REST API) sits above the engine and reaches it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#cbd5e1"/>
+    </marker>
+  </defs>
+  <text x="480.0" y="22.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">CLIENTS</text>
+  <rect x="40.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="90.6" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">HomeTube</text>
+  <rect x="151.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="201.9" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Studio</text>
+  <rect x="262.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="313.1" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Console</text>
+  <rect x="373.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="424.4" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Extension</text>
+  <rect x="485.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="535.6" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">MCP server</text>
+  <rect x="596.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="646.9" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">CLI</text>
+  <rect x="707.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="758.1" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Python SDK</text>
+  <rect x="818.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="869.4" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">REST API</text>
+  <path d="M 90.6 72.0 L 90.6 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 201.9 72.0 L 201.9 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 313.1 72.0 L 313.1 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 424.4 72.0 L 424.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 535.6 72.0 L 535.6 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 646.9 72.0 L 646.9 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 758.1 72.0 L 758.1 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 869.4 72.0 L 869.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 90.6 92.0 L 869.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 480.0 92.0 L 480.0 146.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <text x="492.0" y="122.0" fill="#64748b" font-size="11" text-anchor="start">one public contract</text>
+  <text x="125.0" y="158.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">SOURCES</text>
+  <rect x="60.0" y="174.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="125.0" y="189.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a URL</text>
+  <rect x="60.0" y="212.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="125.0" y="227.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a file</text>
+  <rect x="60.0" y="250.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
+  <text x="125.0" y="265.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">text</text>
+  <path d="M 190.0 189.0 L 208.0 189.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 190.0 227.0 L 208.0 227.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 190.0 265.0 L 208.0 265.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 208.0 189.0 L 208.0 265.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M 208.0 227.0 L 244.0 227.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <rect x="250" y="152" width="460" height="150" rx="14" fill="#1d4ed8" stroke="#1d4ed8"/>
+  <text x="480.0" y="186" fill="#ffffff" font-size="20" font-weight="650" text-anchor="middle">Content engine</text>
+  <text x="480.0" y="208.0" fill="#bfdbfe" font-size="11.5" text-anchor="middle">self-hosted · the only business logic</text>
+  <rect x="274.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="321.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">analyze</text>
+  <rect x="380.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="427.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">plan</text>
+  <rect x="486.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="533.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">run</text>
+  <rect x="592.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
+  <text x="639.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">deliver</text>
+  <path d="M 480.0 302.0 L 480.0 352.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
+  <text x="492.0" y="328.0" fill="#64748b" font-size="11" text-anchor="start">delivered where you want them</text>
+  <text x="480.0" y="368.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">ARTIFACTS</text>
+  <rect x="40.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="90.6" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">video</text>
+  <rect x="151.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="201.9" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">audio</text>
+  <rect x="262.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="313.1" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">subtitles</text>
+  <rect x="373.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="424.4" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">transcript</text>
+  <rect x="485.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="535.6" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">summary</text>
+  <rect x="596.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="646.9" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">translation</text>
+  <rect x="707.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="758.1" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">chapters</text>
+  <rect x="818.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
+  <text x="869.4" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">PDF</text>
+  <text x="480.0" y="436.0" fill="#64748b" font-size="11" text-anchor="middle">…and metadata, images, Markdown, keyframes</text>
+</svg>

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Generate the README's architecture diagram, once per colour scheme.
+
+The README opens with a picture because the first question a visitor has is
+structural — *what is this thing, and where do I stand in it* — and two dense
+paragraphs answer that more slowly than one drawing. The shape is the argument:
+sources go in on the left, artifacts come out at the bottom, every client sits
+above the engine rather than inside it, and they all reach it through one
+contract.
+
+GitHub picks between two files with `<picture media="(prefers-color-scheme:…)">`
+— the only mechanism that follows the *site* theme rather than the operating
+system's. So the diagram exists twice, which is exactly the kind of duplication
+that rots: someone adds a client, edits the light file, ships, and the dark
+file quietly keeps the old list. Hence one geometry, two palettes, and
+`tests/test_readme_diagram.py` to fail when the committed SVGs go stale.
+
+Standard library only: this runs inside the plain test venv on CI.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from xml.sax.saxutils import escape
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+ASSETS = REPO / "docs" / "assets"
+TARGETS = {
+    "light": ASSETS / "architecture-light.svg",
+    "dark": ASSETS / "architecture-dark.svg",
+}
+
+# --- the content, in one place so the two files cannot disagree ------------------
+
+CLIENTS = (
+    "HomeTube",
+    "Studio",
+    "Console",
+    "Extension",
+    "MCP server",
+    "CLI",
+    "Python SDK",
+    "REST API",
+)
+SOURCES = ("a URL", "a file", "text")
+STEPS = ("analyze", "plan", "run", "deliver")
+ARTIFACTS = (
+    "video",
+    "audio",
+    "subtitles",
+    "transcript",
+    "summary",
+    "translation",
+    "chapters",
+    "PDF",
+)
+ALSO = "…and metadata, images, Markdown, keyframes"
+
+# --- geometry --------------------------------------------------------------------
+#
+# One coordinate system, computed rather than typed, so a ninth client re-flows
+# the row instead of overlapping the eighth.
+
+W, H = 960, 476
+MARGIN = 40
+ROW_GAP = 10
+
+ENGINE = {"x": 250, "y": 152, "w": 460, "h": 150, "rx": 14}
+CLIENT_ROW_Y, CHIP_H = 38, 34
+BUS_Y = 92
+SOURCE_X, SOURCE_W, SOURCE_H = 60, 130, 30
+ARTIFACT_ROW_Y = 380
+
+FONT = (
+    "ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',"
+    "Inter,Roboto,Helvetica,Arial,sans-serif"
+)
+
+PALETTES = {
+    # The engine is the same blue in both schemes: it is the one element whose
+    # job is to read as the centre, and a colour that flips loses that.
+    "light": {
+        "muted": "#64748b",
+        "line": "#cbd5e1",
+        "chip_fill": "#ffffff",
+        "chip_stroke": "#e2e8f0",
+        "chip_text": "#334155",
+        "engine_fill": "#1d4ed8",
+        "engine_stroke": "#1d4ed8",
+        "engine_text": "#ffffff",
+        "engine_sub": "#bfdbfe",
+        "pill_fill": "#ffffff26",
+        "pill_stroke": "#ffffff40",
+        "pill_text": "#eaf1ff",
+        "out_fill": "#f0fdf4",
+        "out_stroke": "#bbf7d0",
+        "out_text": "#166534",
+    },
+    "dark": {
+        "muted": "#8b949e",
+        "line": "#30363d",
+        "chip_fill": "#161b22",
+        "chip_stroke": "#30363d",
+        "chip_text": "#c9d1d9",
+        "engine_fill": "#1f6feb",
+        "engine_stroke": "#1f6feb",
+        "engine_text": "#ffffff",
+        "engine_sub": "#cddffb",
+        "pill_fill": "#ffffff26",
+        "pill_stroke": "#ffffff40",
+        "pill_text": "#eaf1ff",
+        "out_fill": "#0d1f14",
+        "out_stroke": "#238636",
+        "out_text": "#7ee787",
+    },
+}
+
+
+# --- primitives ------------------------------------------------------------------
+
+
+def _row(count: int) -> tuple[float, float]:
+    """Chip width and stride for `count` chips spanning the margins."""
+    span = W - 2 * MARGIN
+    width = (span - ROW_GAP * (count - 1)) / count
+    return width, width + ROW_GAP
+
+
+def _chip(x, y, w, h, label, fill, stroke, text, size=12.5, weight=500, rx=9):
+    cx, cy = x + w / 2, y + h / 2
+    return (
+        f'  <rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{h:.1f}" '
+        f'rx="{rx}" fill="{fill}" stroke="{stroke}"/>\n'
+        f'  <text x="{cx:.1f}" y="{cy:.1f}" fill="{text}" font-size="{size}" '
+        f'font-weight="{weight}" text-anchor="middle" dominant-baseline="central">'
+        f"{escape(label)}</text>\n"
+    )
+
+
+def _label(x, y, label, fill, size=10, anchor="middle", weight=600, spacing=1.7):
+    return (
+        f'  <text x="{x:.1f}" y="{y:.1f}" fill="{fill}" font-size="{size}" '
+        f'font-weight="{weight}" letter-spacing="{spacing}" text-anchor="{anchor}">'
+        f"{escape(label)}</text>\n"
+    )
+
+
+def _note(x, y, label, fill, size=11.5, anchor="middle"):
+    return (
+        f'  <text x="{x:.1f}" y="{y:.1f}" fill="{fill}" font-size="{size}" '
+        f'text-anchor="{anchor}">{escape(label)}</text>\n'
+    )
+
+
+def _line(x1, y1, x2, y2, stroke, arrow=False):
+    head = ' marker-end="url(#arrow)"' if arrow else ""
+    return (
+        f'  <path d="M {x1:.1f} {y1:.1f} L {x2:.1f} {y2:.1f}" stroke="{stroke}" '
+        f'stroke-width="1.5" fill="none" stroke-linecap="round"{head}/>\n'
+    )
+
+
+# --- the drawing -----------------------------------------------------------------
+
+
+def render(scheme: str) -> str:
+    p = PALETTES[scheme]
+    cx = W / 2
+    out = []
+
+    out.append(
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" '
+        f'width="{W}" height="{H}" font-family="{FONT}" role="img" '
+        f'aria-labelledby="title desc">\n'
+        f"  <title id=\"title\">Content's architecture</title>\n"
+        f'  <desc id="desc">Sources — a URL, a file, or text — enter one '
+        f"self-hosted engine that analyzes, plans, runs and delivers. Every "
+        f"client (HomeTube, Studio, Console, the browser extension, the MCP "
+        f"server, the CLI, the SDK and the REST API) sits above the engine and "
+        f"reaches it through the same public contract. Artifacts come out: "
+        f"video, audio, subtitles, transcript, summary, translation, chapters "
+        f"and PDF.</desc>\n"
+        f"  <defs>\n"
+        f'    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" '
+        f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">\n'
+        f'      <path d="M 0 0 L 10 5 L 0 10 z" fill="{p["line"]}"/>\n'
+        f"    </marker>\n"
+        f"  </defs>\n"
+    )
+
+    # Clients, in a row, converging on one bus rather than eight diagonals.
+    out.append(_label(cx, 22, "CLIENTS", p["muted"]))
+    cw, stride = _row(len(CLIENTS))
+    centers = []
+    for i, name in enumerate(CLIENTS):
+        x = MARGIN + i * stride
+        centers.append(x + cw / 2)
+        out.append(
+            _chip(
+                x,
+                CLIENT_ROW_Y,
+                cw,
+                CHIP_H,
+                name,
+                p["chip_fill"],
+                p["chip_stroke"],
+                p["chip_text"],
+            )
+        )
+    for c in centers:
+        out.append(_line(c, CLIENT_ROW_Y + CHIP_H, c, BUS_Y, p["line"]))
+    out.append(_line(centers[0], BUS_Y, centers[-1], BUS_Y, p["line"]))
+    out.append(_line(cx, BUS_Y, cx, ENGINE["y"] - 6, p["line"], arrow=True))
+    out.append(
+        _note(cx + 12, BUS_Y + 30, "one public contract", p["muted"], 11, "start")
+    )
+
+    # Sources, entering from the left.
+    mid = ENGINE["y"] + ENGINE["h"] / 2
+    src_cx = SOURCE_X + SOURCE_W / 2
+    block = len(SOURCES) * SOURCE_H + (len(SOURCES) - 1) * 8
+    top = mid - block / 2
+    out.append(_label(src_cx, top - 16, "SOURCES", p["muted"]))
+    for i, name in enumerate(SOURCES):
+        out.append(
+            _chip(
+                SOURCE_X,
+                top + i * (SOURCE_H + 8),
+                SOURCE_W,
+                SOURCE_H,
+                name,
+                p["chip_fill"],
+                p["chip_stroke"],
+                p["chip_text"],
+                size=12,
+            )
+        )
+    # A spine, not a single arrow off the middle chip: drawn straight, the
+    # arrow left of the engine lines up with "a file" and reads as though the
+    # other two go nowhere. Same manifold as the clients, for the same reason.
+    spine = SOURCE_X + SOURCE_W + 18
+    for i in range(len(SOURCES)):
+        y = top + i * (SOURCE_H + 8) + SOURCE_H / 2
+        out.append(_line(SOURCE_X + SOURCE_W, y, spine, y, p["line"]))
+    out.append(_line(spine, top + SOURCE_H / 2, spine, mid + block / 2 - SOURCE_H / 2, p["line"]))
+    out.append(_line(spine, mid, ENGINE["x"] - 6, mid, p["line"], arrow=True))
+
+    # The engine.
+    out.append(
+        f'  <rect x="{ENGINE["x"]}" y="{ENGINE["y"]}" width="{ENGINE["w"]}" '
+        f'height="{ENGINE["h"]}" rx="{ENGINE["rx"]}" fill="{p["engine_fill"]}" '
+        f'stroke="{p["engine_stroke"]}"/>\n'
+    )
+    out.append(
+        f'  <text x="{cx}" y="{ENGINE["y"] + 34}" fill="{p["engine_text"]}" '
+        f'font-size="20" font-weight="650" text-anchor="middle">Content engine</text>\n'
+    )
+    out.append(
+        _note(
+            cx,
+            ENGINE["y"] + 56,
+            "self-hosted · the only business logic",
+            p["engine_sub"],
+        )
+    )
+    pw, pstride = (ENGINE["w"] - 48 - 12 * (len(STEPS) - 1)) / len(STEPS), 0
+    pstride = pw + 12
+    for i, step in enumerate(STEPS):
+        out.append(
+            _chip(
+                ENGINE["x"] + 24 + i * pstride,
+                ENGINE["y"] + 78,
+                pw,
+                32,
+                step,
+                p["pill_fill"],
+                p["pill_stroke"],
+                p["pill_text"],
+                size=12,
+                rx=8,
+            )
+        )
+
+    # Artifacts, coming out at the bottom.
+    out.append(
+        _line(cx, ENGINE["y"] + ENGINE["h"], cx, ARTIFACT_ROW_Y - 28, p["line"], True)
+    )
+    out.append(
+        _note(
+            cx + 12,
+            ENGINE["y"] + ENGINE["h"] + 26,
+            "delivered where you want them",
+            p["muted"],
+            11,
+            "start",
+        )
+    )
+    out.append(_label(cx, ARTIFACT_ROW_Y - 12, "ARTIFACTS", p["muted"]))
+    aw, astride = _row(len(ARTIFACTS))
+    for i, name in enumerate(ARTIFACTS):
+        out.append(
+            _chip(
+                MARGIN + i * astride,
+                ARTIFACT_ROW_Y,
+                aw,
+                CHIP_H,
+                name,
+                p["out_fill"],
+                p["out_stroke"],
+                p["out_text"],
+            )
+        )
+    out.append(_note(cx, ARTIFACT_ROW_Y + CHIP_H + 22, ALSO, p["muted"], 11))
+
+    out.append("</svg>\n")
+    return "".join(out)
+
+
+def main() -> None:
+    ASSETS.mkdir(parents=True, exist_ok=True)
+    for scheme, target in TARGETS.items():
+        target.write_text(render(scheme))
+        print(f"wrote {target.relative_to(REPO)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_readme_diagram.py
+++ b/tests/test_readme_diagram.py
@@ -1,0 +1,79 @@
+"""The README's diagram exists twice, and must say the same thing twice.
+
+GitHub chooses between a light and a dark SVG with `<picture>` — the only
+mechanism that follows the *site* theme rather than the operating system's. Two
+files is therefore not a choice, but it is the kind of duplication that rots
+silently: a ninth client gets added to the light file, ships, and the dark
+readers keep seeing eight. So both are generated from one geometry
+(`make readme-diagram`) and this guard fails when a committed copy is stale.
+
+Standard library only, deliberately: the root suite runs in the plain test
+venv, which carries no XML or SVG library beyond what ships with Python.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+from gen_readme_diagram import ARTIFACTS, CLIENTS, MARGIN, SOURCES, TARGETS, W, render
+
+README = REPO / "README.md"
+
+
+def test_the_committed_diagrams_match_their_source():
+    for scheme, target in TARGETS.items():
+        assert target.read_text() == render(scheme), (
+            f"{target.relative_to(REPO)} is stale — the generator changed "
+            "without regenerating it. Run: make readme-diagram"
+        )
+
+
+def test_both_schemes_carry_the_same_words():
+    """The whole reason this guard exists. Colours may differ; nothing else may."""
+    texts = {
+        scheme: [
+            (e.text or "").strip()
+            for e in ET.fromstring(target.read_text()).iter(
+                "{http://www.w3.org/2000/svg}text"
+            )
+        ]
+        for scheme, target in TARGETS.items()
+    }
+    assert texts["light"] == texts["dark"]
+    for name in (*CLIENTS, *SOURCES, *ARTIFACTS):
+        assert name in texts["light"], f"{name} is drawn nowhere"
+
+
+def test_no_chip_escapes_the_canvas():
+    """The rows are computed, not typed, so a ninth client re-flows the row
+    instead of sliding off the edge. This is what pins that."""
+    for target in TARGETS.values():
+        root = ET.fromstring(target.read_text())
+        for rect in root.iter("{http://www.w3.org/2000/svg}rect"):
+            left = float(rect.get("x", 0))
+            right = left + float(rect.get("width", 0))
+            assert left >= MARGIN - 0.5 and right <= W - MARGIN + 0.5, (
+                f"a box spans {left}..{right}, outside the {MARGIN}px margins"
+            )
+
+
+def test_the_readme_offers_both_files_and_describes_the_picture():
+    """A `<source>` without its `<img>` fallback renders as nothing at all on
+    any surface that does not implement `<picture>` — and the alt text is the
+    only version of this diagram a screen reader ever gets."""
+    readme = README.read_text()
+    for target in TARGETS.values():
+        assert str(target.relative_to(REPO)) in readme, target
+
+    picture = re.search(r"<picture>.*?</picture>", readme, re.DOTALL)
+    assert picture, "the diagram is not published through <picture>"
+    block = picture.group(0)
+    assert 'media="(prefers-color-scheme: dark)"' in block
+    alt = re.search(r'alt="([^"]+)"', block)
+    assert alt and len(alt.group(1)) > 120, "the diagram needs a real description"


### PR DESCRIPTION
**Preview it rendered:** [github.com/LatentNoise/content/tree/readme-architecture-diagram](https://github.com/LatentNoise/content/tree/readme-architecture-diagram) — and flip your GitHub theme, there are two files.

The first question a visitor has is structural — *what is this thing, and where do I stand in it* — and two dense paragraphs answer that more slowly than one drawing. The diagram now sits above the fold and above the prose, with the HomeTube demo directly under it as the first client you actually see working.

## The shape is the argument

Sources enter from the left. The engine is one block in the middle, labelled as the only business logic. All eight clients sit **above** it rather than inside it, and converge on a single line marked *"one public contract"*. Artifacts come out at the bottom. Someone who reads nothing else has still been told that no client is a layer the others pass through.

## Why SVG, and why twice

Mermaid can't give this layout control or a palette. And it's committed twice on purpose: GitHub's `<picture media="(prefers-color-scheme: dark)">` is the only mechanism that follows the **site** theme — a single SVG with an internal media query follows the *operating system* instead, and gets it wrong for anyone whose two settings disagree.

Two files that must say the same thing is exactly the duplication that rots — someone adds a ninth client to the light one, ships, and dark readers keep seeing eight. So both come from one geometry and one word list (`make readme-diagram`), and `tests/test_readme_diagram.py` fails on:

- a stale committed copy,
- the two schemes disagreeing about **any** text,
- a box escaping the margins — the rows are computed, not typed, so a ninth client re-flows the row instead of sliding off the edge,
- the `<picture>` losing its `<img>` fallback or its alt text.

I checked the guard isn't vacuous: hand-editing one file to say `HomeTubez` fails it.

## Two small things worth a look

- `.gitignore` gains `!docs/assets/*.svg`. SVG is text, so it belongs in a text-only allowlist; binary media stays out and keeps going to release attachments.
- Both renderings were inspected as images, the dark one **against GitHub's own background** rather than on white — transparent chips read very differently there, and the first version had an arrow that appeared to connect only "a file" to the engine.

`make validate` green. Adding or renaming a client is now a one-line edit in `scripts/gen_readme_diagram.py`, so say the word if you want different labels — "Studio" and "Console" are short for space, and I can widen the row instead.