### PR TITLE
A warmer diagram: curves, and a line under every name

### DIFF
--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -1,80 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 476" width="960" height="476" font-family="ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,Helvetica,Arial,sans-serif" role="img" aria-labelledby="title desc">
-  <title id="title">Content's architecture</title>
-  <desc id="desc">Sources — a URL, a file, or text — enter one self-hosted engine that analyzes, plans, runs and delivers. Every client (HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the SDK and the REST API) sits above the engine and reaches it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 772" width="1280" height="772" role="img" aria-labelledby="t d">
+  <title id="t">Content's architecture</title>
+  <desc id="d">Sources — a URL, a file, or text — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#30363d"/>
-    </marker>
+    <linearGradient id="eg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f6feb"/><stop offset="58%" stop-color="#4f46e5"/><stop offset="100%" stop-color="#8957e5"/></linearGradient>
+    <linearGradient id="fl" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#3fb950"/><stop offset="45%" stop-color="#58a6ff"/><stop offset="100%" stop-color="#a371f7"/></linearGradient>
+    <filter id="lift" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#010409" flood-opacity="0.0"/></filter>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="12" stdDeviation="22" flood-color="#1f6feb" flood-opacity="0.28"/></filter>
+    <style>
+      text { font-family: Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+      .lb { font-size: 15px; font-weight: 700; letter-spacing: .18em; }
+      .ct { font-size: 17px; font-weight: 700; }
+      .cs { font-size: 13.5px; font-weight: 500; }
+    </style>
   </defs>
-  <text x="480.0" y="22.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">CLIENTS</text>
-  <rect x="40.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="90.6" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">HomeTube</text>
-  <rect x="151.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="201.9" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Studio</text>
-  <rect x="262.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="313.1" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Console</text>
-  <rect x="373.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="424.4" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Extension</text>
-  <rect x="485.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="535.6" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">MCP server</text>
-  <rect x="596.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="646.9" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">CLI</text>
-  <rect x="707.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="758.1" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Python SDK</text>
-  <rect x="818.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="869.4" y="55.0" fill="#c9d1d9" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">REST API</text>
-  <path d="M 90.6 72.0 L 90.6 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 201.9 72.0 L 201.9 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 313.1 72.0 L 313.1 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 424.4 72.0 L 424.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 535.6 72.0 L 535.6 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 646.9 72.0 L 646.9 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 758.1 72.0 L 758.1 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 869.4 72.0 L 869.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 90.6 92.0 L 869.4 92.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 480.0 92.0 L 480.0 146.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <text x="492.0" y="122.0" fill="#8b949e" font-size="11" text-anchor="start">one public contract</text>
-  <text x="125.0" y="158.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">SOURCES</text>
-  <rect x="60.0" y="174.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="125.0" y="189.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a URL</text>
-  <rect x="60.0" y="212.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="125.0" y="227.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a file</text>
-  <rect x="60.0" y="250.0" width="130.0" height="30.0" rx="9" fill="#161b22" stroke="#30363d"/>
-  <text x="125.0" y="265.0" fill="#c9d1d9" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">text</text>
-  <path d="M 190.0 189.0 L 208.0 189.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 190.0 227.0 L 208.0 227.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 190.0 265.0 L 208.0 265.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 208.0 189.0 L 208.0 265.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 208.0 227.0 L 244.0 227.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <rect x="250" y="152" width="460" height="150" rx="14" fill="#1f6feb" stroke="#1f6feb"/>
-  <text x="480.0" y="186" fill="#ffffff" font-size="20" font-weight="650" text-anchor="middle">Content engine</text>
-  <text x="480.0" y="208.0" fill="#cddffb" font-size="11.5" text-anchor="middle">self-hosted · the only business logic</text>
-  <rect x="274.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="321.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">analyze</text>
-  <rect x="380.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="427.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">plan</text>
-  <rect x="486.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="533.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">run</text>
-  <rect x="592.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="639.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">deliver</text>
-  <path d="M 480.0 302.0 L 480.0 352.0" stroke="#30363d" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <text x="492.0" y="328.0" fill="#8b949e" font-size="11" text-anchor="start">delivered where you want them</text>
-  <text x="480.0" y="368.0" fill="#8b949e" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">ARTIFACTS</text>
-  <rect x="40.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="90.6" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">video</text>
-  <rect x="151.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="201.9" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">audio</text>
-  <rect x="262.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="313.1" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">subtitles</text>
-  <rect x="373.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="424.4" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">transcript</text>
-  <rect x="485.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="535.6" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">summary</text>
-  <rect x="596.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="646.9" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">translation</text>
-  <rect x="707.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="758.1" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">chapters</text>
-  <rect x="818.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#0d1f14" stroke="#238636"/>
-  <text x="869.4" y="397.0" fill="#7ee787" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">PDF</text>
-  <text x="480.0" y="436.0" fill="#8b949e" font-size="11" text-anchor="middle">…and metadata, images, Markdown, keyframes</text>
+  <text x="800.0" y="30.0" class="lb" fill="#8b949e" text-anchor="middle">CLIENTS</text>
+  <rect x="360.0" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="410.6" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">HomeTube</text>
+  <text x="410.6" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">YouTube UI</text>
+  <rect x="471.2" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="521.9" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">Studio</text>
+  <text x="521.9" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Web UI</text>
+  <rect x="582.5" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="633.1" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">Console</text>
+  <text x="633.1" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Operations</text>
+  <rect x="693.8" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="744.4" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">Extension</text>
+  <text x="744.4" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Browser</text>
+  <rect x="805.0" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="855.6" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">MCP server</text>
+  <text x="855.6" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Agents</text>
+  <rect x="916.2" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="966.9" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">CLI</text>
+  <text x="966.9" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Terminal</text>
+  <rect x="1027.5" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="1078.1" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">Python SDK</text>
+  <text x="1078.1" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Code</text>
+  <rect x="1138.8" y="52.0" width="101.2" height="64.0" rx="18" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <text x="1189.4" y="80.0" class="ct" fill="#e6edf3" text-anchor="middle">REST API</text>
+  <text x="1189.4" y="101.0" class="cs" fill="#8b949e" text-anchor="middle">Anything</text>
+  <path d="M 410.6 116.0 C 410.6 160.0, 450.0 152.0, 450.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 521.9 116.0 C 521.9 160.0, 550.0 152.0, 550.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 633.1 116.0 C 633.1 160.0, 650.0 152.0, 650.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 744.4 116.0 C 744.4 160.0, 750.0 152.0, 750.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 855.6 116.0 C 855.6 160.0, 850.0 152.0, 850.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 966.9 116.0 C 966.9 160.0, 950.0 152.0, 950.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 1078.1 116.0 C 1078.1 160.0, 1050.0 152.0, 1050.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 1189.4 116.0 C 1189.4 160.0, 1150.0 152.0, 1150.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <text x="44.0" y="218.0" class="lb" fill="#8b949e" text-anchor="start">SOURCES</text>
+  <rect x="40" y="240.0" width="240" height="62" rx="17" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <g transform="translate(74,271.0)">
+    <circle r="13" fill="#0d1f14" stroke="#238636"/>
+    <path d="M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="267.0" class="ct" fill="#e6edf3" text-anchor="start">URL</text>
+  <text x="100" y="287.0" class="cs" fill="#8b949e" text-anchor="start">one or a collection</text>
+  <path d="M 286 271.0 C 336 271.0, 304 315.0, 348 315.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 315.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
+  <rect x="40" y="318.0" width="240" height="62" rx="17" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <g transform="translate(74,349.0)">
+    <circle r="13" fill="#0d1f14" stroke="#238636"/>
+    <path d="M-5 -6h7l4 4v8h-11z M2 -6v4h4" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="345.0" class="ct" fill="#e6edf3" text-anchor="start">File</text>
+  <text x="100" y="365.0" class="cs" fill="#8b949e" text-anchor="start">one or many</text>
+  <path d="M 286 349.0 C 336 349.0, 304 349.0, 348 349.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 349.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
+  <rect x="40" y="396.0" width="240" height="62" rx="17" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
+  <g transform="translate(74,427.0)">
+    <circle r="13" fill="#0d1f14" stroke="#238636"/>
+    <path d="M-6 -4h12 M-6 0h9 M-6 4h7" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="423.0" class="ct" fill="#e6edf3" text-anchor="start">Text</text>
+  <text x="100" y="443.0" class="cs" fill="#8b949e" text-anchor="start">single or batched</text>
+  <path d="M 286 427.0 C 336 427.0, 304 383.0, 348 383.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 383.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
+  <rect x="360" y="196" width="880" height="306" rx="44" fill="url(#eg)" filter="url(#glow)"/>
+  <text x="800.0" y="258" text-anchor="middle" fill="#ffffff" font-size="36" font-weight="800" letter-spacing="-0.02em">Content engine</text>
+  <text x="800.0" y="288" text-anchor="middle" fill="#dbeafe" font-size="16" font-weight="500">self-hosted · persistent · all business logic lives here</text>
+  <rect x="436.0" y="304" width="354.0" height="34" rx="17" fill="#ffffff" fill-opacity="0.10" stroke="#ffffff" stroke-opacity="0.22"/>
+  <circle cx="458.0" cy="321" r="4.5" fill="#86efac"/>
+  <text x="627.0" y="326" text-anchor="middle" fill="#eef2ff" font-size="13.5" font-weight="700">all clients · one public contract</text>
+  <rect x="810.0" y="304" width="354.0" height="34" rx="17" fill="#ffffff" fill-opacity="0.10" stroke="#ffffff" stroke-opacity="0.22"/>
+  <circle cx="832.0" cy="321" r="4.5" fill="#86efac"/>
+  <circle cx="847.0" cy="321" r="4.5" fill="#93c5fd"/>
+  <circle cx="862.0" cy="321" r="4.5" fill="#c4b5fd"/>
+  <text x="1001.0" y="326" text-anchor="middle" fill="#eef2ff" font-size="13.5" font-weight="700">independent persistent jobs</text>
+  <rect x="404.0" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="494.8" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Analyze</text>
+  <text x="494.8" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">understand</text>
+  <rect x="607.5" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="698.2" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Plan</text>
+  <text x="698.2" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">resolve the path</text>
+  <path d="M 585.5 407 H 607.5" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <rect x="811.0" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="901.8" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Run</text>
+  <text x="901.8" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">process</text>
+  <path d="M 789.0 407 H 811.0" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <rect x="1014.5" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="1105.2" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Deliver</text>
+  <text x="1105.2" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">where you want</text>
+  <path d="M 992.5 407 H 1014.5" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <path d="M 800.0 502 V 560.0" stroke="#a371f7" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+  <path d="M 800.0 572.0 l-8 -13 h16 z" fill="#a371f7"/>
+  <text x="800.0" y="594.0" class="lb" fill="#8b949e" text-anchor="middle">ARTIFACTS</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 110.6 624.9, 110.6 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="40.0" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="110.6" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Video</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 261.9 624.9, 261.9 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="191.2" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="261.9" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Audio</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 413.1 624.9, 413.1 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="342.5" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="413.1" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Subtitles</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 564.4 624.9, 564.4 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="493.8" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="564.4" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Transcript</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 715.6 624.9, 715.6 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="645.0" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="715.6" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Summary</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 866.9 624.9, 866.9 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="796.2" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="866.9" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Translation</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 1018.1 624.9, 1018.1 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="947.5" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="1018.1" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">Chapters</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 1169.4 624.9, 1169.4 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="1098.8" y="648.0" width="141.2" height="66.0" rx="18" fill="#0d1f14" stroke="#238636" filter="url(#lift)"/>
+  <text x="1169.4" y="687.0" class="ct" fill="#7ee787" text-anchor="middle">PDF</text>
+  <text x="800.0" y="748" text-anchor="middle" fill="#8b949e" font-size="13.5" font-weight="600">…plus metadata, images, Markdown, keyframes, thumbnails, and more.</text>
 </svg>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -1,80 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 476" width="960" height="476" font-family="ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',Inter,Roboto,Helvetica,Arial,sans-serif" role="img" aria-labelledby="title desc">
-  <title id="title">Content's architecture</title>
-  <desc id="desc">Sources — a URL, a file, or text — enter one self-hosted engine that analyzes, plans, runs and delivers. Every client (HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the SDK and the REST API) sits above the engine and reaches it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 772" width="1280" height="772" role="img" aria-labelledby="t d">
+  <title id="t">Content's architecture</title>
+  <desc id="d">Sources — a URL, a file, or text — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
   <defs>
-    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="#cbd5e1"/>
-    </marker>
+    <linearGradient id="eg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#2563eb"/><stop offset="58%" stop-color="#4f46e5"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient>
+    <linearGradient id="fl" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22c55e"/><stop offset="45%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient>
+    <filter id="lift" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="#0f172a" flood-opacity="0.09"/></filter>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="180%"><feDropShadow dx="0" dy="12" stdDeviation="22" flood-color="#3157d5" flood-opacity="0.2"/></filter>
+    <style>
+      text { font-family: Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif; }
+      .lb { font-size: 15px; font-weight: 700; letter-spacing: .18em; }
+      .ct { font-size: 17px; font-weight: 700; }
+      .cs { font-size: 13.5px; font-weight: 500; }
+    </style>
   </defs>
-  <text x="480.0" y="22.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">CLIENTS</text>
-  <rect x="40.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="90.6" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">HomeTube</text>
-  <rect x="151.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="201.9" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Studio</text>
-  <rect x="262.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="313.1" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Console</text>
-  <rect x="373.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="424.4" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Extension</text>
-  <rect x="485.0" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="535.6" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">MCP server</text>
-  <rect x="596.2" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="646.9" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">CLI</text>
-  <rect x="707.5" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="758.1" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">Python SDK</text>
-  <rect x="818.8" y="38.0" width="101.2" height="34.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="869.4" y="55.0" fill="#334155" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">REST API</text>
-  <path d="M 90.6 72.0 L 90.6 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 201.9 72.0 L 201.9 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 313.1 72.0 L 313.1 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 424.4 72.0 L 424.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 535.6 72.0 L 535.6 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 646.9 72.0 L 646.9 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 758.1 72.0 L 758.1 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 869.4 72.0 L 869.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 90.6 92.0 L 869.4 92.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 480.0 92.0 L 480.0 146.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <text x="492.0" y="122.0" fill="#64748b" font-size="11" text-anchor="start">one public contract</text>
-  <text x="125.0" y="158.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">SOURCES</text>
-  <rect x="60.0" y="174.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="125.0" y="189.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a URL</text>
-  <rect x="60.0" y="212.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="125.0" y="227.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">a file</text>
-  <rect x="60.0" y="250.0" width="130.0" height="30.0" rx="9" fill="#ffffff" stroke="#e2e8f0"/>
-  <text x="125.0" y="265.0" fill="#334155" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">text</text>
-  <path d="M 190.0 189.0 L 208.0 189.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 190.0 227.0 L 208.0 227.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 190.0 265.0 L 208.0 265.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 208.0 189.0 L 208.0 265.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M 208.0 227.0 L 244.0 227.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <rect x="250" y="152" width="460" height="150" rx="14" fill="#1d4ed8" stroke="#1d4ed8"/>
-  <text x="480.0" y="186" fill="#ffffff" font-size="20" font-weight="650" text-anchor="middle">Content engine</text>
-  <text x="480.0" y="208.0" fill="#bfdbfe" font-size="11.5" text-anchor="middle">self-hosted · the only business logic</text>
-  <rect x="274.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="321.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">analyze</text>
-  <rect x="380.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="427.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">plan</text>
-  <rect x="486.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="533.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">run</text>
-  <rect x="592.0" y="230.0" width="94.0" height="32.0" rx="8" fill="#ffffff26" stroke="#ffffff40"/>
-  <text x="639.0" y="246.0" fill="#eaf1ff" font-size="12" font-weight="500" text-anchor="middle" dominant-baseline="central">deliver</text>
-  <path d="M 480.0 302.0 L 480.0 352.0" stroke="#cbd5e1" stroke-width="1.5" fill="none" stroke-linecap="round" marker-end="url(#arrow)"/>
-  <text x="492.0" y="328.0" fill="#64748b" font-size="11" text-anchor="start">delivered where you want them</text>
-  <text x="480.0" y="368.0" fill="#64748b" font-size="10" font-weight="600" letter-spacing="1.7" text-anchor="middle">ARTIFACTS</text>
-  <rect x="40.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="90.6" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">video</text>
-  <rect x="151.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="201.9" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">audio</text>
-  <rect x="262.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="313.1" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">subtitles</text>
-  <rect x="373.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="424.4" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">transcript</text>
-  <rect x="485.0" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="535.6" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">summary</text>
-  <rect x="596.2" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="646.9" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">translation</text>
-  <rect x="707.5" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="758.1" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">chapters</text>
-  <rect x="818.8" y="380.0" width="101.2" height="34.0" rx="9" fill="#f0fdf4" stroke="#bbf7d0"/>
-  <text x="869.4" y="397.0" fill="#166534" font-size="12.5" font-weight="500" text-anchor="middle" dominant-baseline="central">PDF</text>
-  <text x="480.0" y="436.0" fill="#64748b" font-size="11" text-anchor="middle">…and metadata, images, Markdown, keyframes</text>
+  <text x="800.0" y="30.0" class="lb" fill="#64748b" text-anchor="middle">CLIENTS</text>
+  <rect x="360.0" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="410.6" y="80.0" class="ct" fill="#172033" text-anchor="middle">HomeTube</text>
+  <text x="410.6" y="101.0" class="cs" fill="#64748b" text-anchor="middle">YouTube UI</text>
+  <rect x="471.2" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="521.9" y="80.0" class="ct" fill="#172033" text-anchor="middle">Studio</text>
+  <text x="521.9" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Web UI</text>
+  <rect x="582.5" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="633.1" y="80.0" class="ct" fill="#172033" text-anchor="middle">Console</text>
+  <text x="633.1" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Operations</text>
+  <rect x="693.8" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="744.4" y="80.0" class="ct" fill="#172033" text-anchor="middle">Extension</text>
+  <text x="744.4" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Browser</text>
+  <rect x="805.0" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="855.6" y="80.0" class="ct" fill="#172033" text-anchor="middle">MCP server</text>
+  <text x="855.6" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Agents</text>
+  <rect x="916.2" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="966.9" y="80.0" class="ct" fill="#172033" text-anchor="middle">CLI</text>
+  <text x="966.9" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Terminal</text>
+  <rect x="1027.5" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="1078.1" y="80.0" class="ct" fill="#172033" text-anchor="middle">Python SDK</text>
+  <text x="1078.1" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Code</text>
+  <rect x="1138.8" y="52.0" width="101.2" height="64.0" rx="18" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <text x="1189.4" y="80.0" class="ct" fill="#172033" text-anchor="middle">REST API</text>
+  <text x="1189.4" y="101.0" class="cs" fill="#64748b" text-anchor="middle">Anything</text>
+  <path d="M 410.6 116.0 C 410.6 160.0, 450.0 152.0, 450.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 521.9 116.0 C 521.9 160.0, 550.0 152.0, 550.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 633.1 116.0 C 633.1 160.0, 650.0 152.0, 650.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 744.4 116.0 C 744.4 160.0, 750.0 152.0, 750.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 855.6 116.0 C 855.6 160.0, 850.0 152.0, 850.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 966.9 116.0 C 966.9 160.0, 950.0 152.0, 950.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 1078.1 116.0 C 1078.1 160.0, 1050.0 152.0, 1050.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <path d="M 1189.4 116.0 C 1189.4 160.0, 1150.0 152.0, 1150.0 196.0" fill="none" stroke="url(#fl)" stroke-width="2.0" stroke-linecap="round" opacity="0.62"/>
+  <text x="44.0" y="218.0" class="lb" fill="#64748b" text-anchor="start">SOURCES</text>
+  <rect x="40" y="240.0" width="240" height="62" rx="17" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <g transform="translate(74,271.0)">
+    <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
+    <path d="M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="267.0" class="ct" fill="#172033" text-anchor="start">URL</text>
+  <text x="100" y="287.0" class="cs" fill="#64748b" text-anchor="start">one or a collection</text>
+  <path d="M 286 271.0 C 336 271.0, 304 315.0, 348 315.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 315.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
+  <rect x="40" y="318.0" width="240" height="62" rx="17" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <g transform="translate(74,349.0)">
+    <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
+    <path d="M-5 -6h7l4 4v8h-11z M2 -6v4h4" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="345.0" class="ct" fill="#172033" text-anchor="start">File</text>
+  <text x="100" y="365.0" class="cs" fill="#64748b" text-anchor="start">one or many</text>
+  <path d="M 286 349.0 C 336 349.0, 304 349.0, 348 349.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 349.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
+  <rect x="40" y="396.0" width="240" height="62" rx="17" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
+  <g transform="translate(74,427.0)">
+    <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
+    <path d="M-6 -4h12 M-6 0h9 M-6 4h7" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="100" y="423.0" class="ct" fill="#172033" text-anchor="start">Text</text>
+  <text x="100" y="443.0" class="cs" fill="#64748b" text-anchor="start">single or batched</text>
+  <path d="M 286 427.0 C 336 427.0, 304 383.0, 348 383.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+  <path d="M 358 383.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
+  <rect x="360" y="196" width="880" height="306" rx="44" fill="url(#eg)" filter="url(#glow)"/>
+  <text x="800.0" y="258" text-anchor="middle" fill="#ffffff" font-size="36" font-weight="800" letter-spacing="-0.02em">Content engine</text>
+  <text x="800.0" y="288" text-anchor="middle" fill="#dbeafe" font-size="16" font-weight="500">self-hosted · persistent · all business logic lives here</text>
+  <rect x="436.0" y="304" width="354.0" height="34" rx="17" fill="#ffffff" fill-opacity="0.10" stroke="#ffffff" stroke-opacity="0.22"/>
+  <circle cx="458.0" cy="321" r="4.5" fill="#86efac"/>
+  <text x="627.0" y="326" text-anchor="middle" fill="#eef2ff" font-size="13.5" font-weight="700">all clients · one public contract</text>
+  <rect x="810.0" y="304" width="354.0" height="34" rx="17" fill="#ffffff" fill-opacity="0.10" stroke="#ffffff" stroke-opacity="0.22"/>
+  <circle cx="832.0" cy="321" r="4.5" fill="#86efac"/>
+  <circle cx="847.0" cy="321" r="4.5" fill="#93c5fd"/>
+  <circle cx="862.0" cy="321" r="4.5" fill="#c4b5fd"/>
+  <text x="1001.0" y="326" text-anchor="middle" fill="#eef2ff" font-size="13.5" font-weight="700">independent persistent jobs</text>
+  <rect x="404.0" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="494.8" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Analyze</text>
+  <text x="494.8" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">understand</text>
+  <rect x="607.5" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="698.2" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Plan</text>
+  <text x="698.2" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">resolve the path</text>
+  <path d="M 585.5 407 H 607.5" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <rect x="811.0" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="901.8" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Run</text>
+  <text x="901.8" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">process</text>
+  <path d="M 789.0 407 H 811.0" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <rect x="1014.5" y="360" width="181.5" height="94" rx="20" fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" stroke-opacity="0.22"/>
+  <text x="1105.2" y="402" text-anchor="middle" fill="#ffffff" font-size="17" font-weight="700">Deliver</text>
+  <text x="1105.2" y="425" text-anchor="middle" fill="#dce7ff" font-size="13">where you want</text>
+  <path d="M 992.5 407 H 1014.5" stroke="#dce7ff" stroke-width="2" opacity="0.7"/>
+  <path d="M 800.0 502 V 560.0" stroke="#4f46e5" stroke-width="3.4" stroke-linecap="round" fill="none"/>
+  <path d="M 800.0 572.0 l-8 -13 h16 z" fill="#4f46e5"/>
+  <text x="800.0" y="594.0" class="lb" fill="#64748b" text-anchor="middle">ARTIFACTS</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 110.6 624.9, 110.6 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="40.0" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="110.6" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Video</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 261.9 624.9, 261.9 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="191.2" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="261.9" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Audio</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 413.1 624.9, 413.1 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="342.5" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="413.1" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Subtitles</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 564.4 624.9, 564.4 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="493.8" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="564.4" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Transcript</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 715.6 624.9, 715.6 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="645.0" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="715.6" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Summary</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 866.9 624.9, 866.9 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="796.2" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="866.9" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Translation</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 1018.1 624.9, 1018.1 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="947.5" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="1018.1" y="687.0" class="ct" fill="#14532d" text-anchor="middle">Chapters</text>
+  <path d="M 800.0 606.0 C 800.0 629.1, 1169.4 624.9, 1169.4 648.0" fill="none" stroke="url(#fl)" stroke-width="1.6" stroke-linecap="round" opacity="0.45"/>
+  <rect x="1098.8" y="648.0" width="141.2" height="66.0" rx="18" fill="#f0fdf4" stroke="#bbf7d0" filter="url(#lift)"/>
+  <text x="1169.4" y="687.0" class="ct" fill="#14532d" text-anchor="middle">PDF</text>
+  <text x="800.0" y="748" text-anchor="middle" fill="#64748b" font-size="13.5" font-weight="600">…plus metadata, images, Markdown, keyframes, thumbnails, and more.</text>
 </svg>

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -4,9 +4,8 @@
 The README opens with a picture because the first question a visitor has is
 structural — *what is this thing, and where do I stand in it* — and two dense
 paragraphs answer that more slowly than one drawing. The shape is the argument:
-sources go in on the left, artifacts come out at the bottom, every client sits
-above the engine rather than inside it, and they all reach it through one
-contract.
+sources feed in from the left, every client sits above the engine rather than
+inside it, and artifacts come out the bottom.
 
 GitHub picks between two files with `<picture media="(prefers-color-scheme:…)">`
 — the only mechanism that follows the *site* theme rather than the operating
@@ -14,6 +13,12 @@ system's. So the diagram exists twice, which is exactly the kind of duplication
 that rots: someone adds a client, edits the light file, ships, and the dark
 file quietly keeps the old list. Hence one geometry, two palettes, and
 `tests/test_readme_diagram.py` to fail when the committed SVGs go stale.
+
+One rule holds the composition together, and it is the one a hand-drawn version
+kept losing: **the clients, the engine and the artifacts share a single axis and
+a single band of width.** Only the sources hang off to the left, because only
+they are upstream. Everything fans from that axis, so the curves stay short and
+symmetrical instead of sweeping across the canvas to correct an offset.
 
 Standard library only: this runs inside the plain test venv on CI.
 """
@@ -30,133 +35,178 @@ TARGETS = {
     "dark": ASSETS / "architecture-dark.svg",
 }
 
-# --- the content, in one place so the two files cannot disagree ------------------
+# --- the words, in one place so the two files cannot disagree --------------------
+#
+# Each is (name, what it is). The second half is what turns a row of nouns into
+# something readable by somebody who has never heard of any of them.
 
 CLIENTS = (
-    "HomeTube",
-    "Studio",
-    "Console",
-    "Extension",
-    "MCP server",
-    "CLI",
-    "Python SDK",
-    "REST API",
+    ("HomeTube", "YouTube UI"),
+    ("Studio", "Web UI"),
+    ("Console", "Operations"),
+    ("Extension", "Browser"),
+    ("MCP server", "Agents"),
+    ("CLI", "Terminal"),
+    ("Python SDK", "Code"),
+    ("REST API", "Anything"),
 )
-SOURCES = ("a URL", "a file", "text")
-STEPS = ("analyze", "plan", "run", "deliver")
+SOURCES = (
+    ("URL", "one or a collection"),
+    ("File", "one or many"),
+    ("Text", "single or batched"),
+)
+STEPS = (
+    ("Analyze", "understand"),
+    ("Plan", "resolve the path"),
+    ("Run", "process"),
+    ("Deliver", "where you want"),
+)
 ARTIFACTS = (
-    "video",
-    "audio",
-    "subtitles",
-    "transcript",
-    "summary",
-    "translation",
-    "chapters",
+    "Video",
+    "Audio",
+    "Subtitles",
+    "Transcript",
+    "Summary",
+    "Translation",
+    "Chapters",
     "PDF",
 )
-ALSO = "…and metadata, images, Markdown, keyframes"
+BADGES = ("all clients · one public contract", "independent persistent jobs")
+ENGINE_SUB = "self-hosted · persistent · all business logic lives here"
+ALSO = "…plus metadata, images, Markdown, keyframes, thumbnails, and more."
 
 # --- geometry --------------------------------------------------------------------
 #
-# One coordinate system, computed rather than typed, so a ninth client re-flows
-# the row instead of overlapping the eighth.
+# Computed, never typed: a ninth client re-flows its row instead of overlapping
+# the eighth, and the fan re-spreads to match.
 
-W, H = 960, 476
+W, H = 1280, 772
 MARGIN = 40
-ROW_GAP = 10
 
-ENGINE = {"x": 250, "y": 152, "w": 460, "h": 150, "rx": 14}
-CLIENT_ROW_Y, CHIP_H = 38, 34
-BUS_Y = 92
-SOURCE_X, SOURCE_W, SOURCE_H = 60, 130, 30
-ARTIFACT_ROW_Y = 380
+# The shared axis. Clients, engine and artifacts all live inside this band;
+# the sources column is the only thing outside it.
+BAND_X0, BAND_X1 = 360, 1240
+AXIS = (BAND_X0 + BAND_X1) / 2
+
+GAP = 10
+CLIENT_Y, CLIENT_H = 52, 64
+ENGINE_Y, ENGINE_H = 196, 306
+ENGINE_R = 44
+SOURCE_X, SOURCE_W, SOURCE_H, SOURCE_GAP = MARGIN, 240, 62, 16
+FAN_Y = 606
+ARTIFACT_Y, ARTIFACT_H = 648, 66
 
 FONT = (
-    "ui-sans-serif,-apple-system,BlinkMacSystemFont,'Segoe UI',"
-    "Inter,Roboto,Helvetica,Arial,sans-serif"
+    'Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",'
+    "Roboto,Helvetica,Arial,sans-serif"
 )
 
 PALETTES = {
-    # The engine is the same blue in both schemes: it is the one element whose
-    # job is to read as the centre, and a colour that flips loses that.
+    # The engine keeps the same blue-to-violet in both schemes: it is the one
+    # element whose job is to read as the centre, and a colour that flips loses
+    # that. Everything around it inverts.
     "light": {
-        "muted": "#64748b",
-        "line": "#cbd5e1",
-        "chip_fill": "#ffffff",
-        "chip_stroke": "#e2e8f0",
-        "chip_text": "#334155",
-        "engine_fill": "#1d4ed8",
-        "engine_stroke": "#1d4ed8",
-        "engine_text": "#ffffff",
-        "engine_sub": "#bfdbfe",
-        "pill_fill": "#ffffff26",
-        "pill_stroke": "#ffffff40",
-        "pill_text": "#eaf1ff",
+        "label": "#64748b",
+        "card_fill": "#ffffff",
+        "card_stroke": "#d7dee9",
+        "card_title": "#172033",
+        "card_sub": "#64748b",
         "out_fill": "#f0fdf4",
         "out_stroke": "#bbf7d0",
-        "out_text": "#166534",
+        "out_title": "#14532d",
+        "icon_fill": "#ecfdf5",
+        "icon_stroke": "#a7f3d0",
+        "icon_ink": "#16a34a",
+        "engine": ("#2563eb", "#4f46e5", "#7c3aed"),
+        "flow": ("#22c55e", "#3b82f6", "#7c3aed"),
+        "arrow": "#4f46e5",
+        "shadow": ("#0f172a", 0.09),
+        "engine_glow": ("#3157d5", 0.20),
     },
     "dark": {
-        "muted": "#8b949e",
-        "line": "#30363d",
-        "chip_fill": "#161b22",
-        "chip_stroke": "#30363d",
-        "chip_text": "#c9d1d9",
-        "engine_fill": "#1f6feb",
-        "engine_stroke": "#1f6feb",
-        "engine_text": "#ffffff",
-        "engine_sub": "#cddffb",
-        "pill_fill": "#ffffff26",
-        "pill_stroke": "#ffffff40",
-        "pill_text": "#eaf1ff",
+        "label": "#8b949e",
+        "card_fill": "#161b22",
+        "card_stroke": "#30363d",
+        "card_title": "#e6edf3",
+        "card_sub": "#8b949e",
         "out_fill": "#0d1f14",
         "out_stroke": "#238636",
-        "out_text": "#7ee787",
+        "out_title": "#7ee787",
+        "icon_fill": "#0d1f14",
+        "icon_stroke": "#238636",
+        "icon_ink": "#3fb950",
+        "engine": ("#1f6feb", "#4f46e5", "#8957e5"),
+        "flow": ("#3fb950", "#58a6ff", "#a371f7"),
+        "arrow": "#a371f7",
+        # A dark drop shadow on a dark page is invisible mud; the cards carry
+        # their own border there and need no lift.
+        "shadow": ("#010409", 0.0),
+        "engine_glow": ("#1f6feb", 0.28),
     },
+}
+
+# Little marks that say what a source *is* without a word. Drawn at the origin
+# and translated into place, so the icon and its chip cannot drift apart.
+SOURCE_ICONS = {
+    "URL": "M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12",
+    "File": "M-5 -6h7l4 4v8h-11z M2 -6v4h4",
+    "Text": "M-6 -4h12 M-6 0h9 M-6 4h7",
 }
 
 
 # --- primitives ------------------------------------------------------------------
 
 
-def _row(count: int) -> tuple[float, float]:
-    """Chip width and stride for `count` chips spanning the margins."""
-    span = W - 2 * MARGIN
-    width = (span - ROW_GAP * (count - 1)) / count
-    return width, width + ROW_GAP
+def _spread(count: int, x0: float, x1: float, gap: float) -> tuple[float, float]:
+    """Item width and stride for `count` items filling x0..x1."""
+    width = ((x1 - x0) - gap * (count - 1)) / count
+    return width, width + gap
 
 
-def _chip(x, y, w, h, label, fill, stroke, text, size=12.5, weight=500, rx=9):
-    cx, cy = x + w / 2, y + h / 2
-    return (
+def _card(x, y, w, h, title, sub, p, *, out=False, rx=18):
+    """A rounded card carrying a name and, under it, what the name means."""
+    fill = p["out_fill"] if out else p["card_fill"]
+    stroke = p["out_stroke"] if out else p["card_stroke"]
+    ink = p["out_title"] if out else p["card_title"]
+    cx = x + w / 2
+    svg = (
         f'  <rect x="{x:.1f}" y="{y:.1f}" width="{w:.1f}" height="{h:.1f}" '
-        f'rx="{rx}" fill="{fill}" stroke="{stroke}"/>\n'
-        f'  <text x="{cx:.1f}" y="{cy:.1f}" fill="{text}" font-size="{size}" '
-        f'font-weight="{weight}" text-anchor="middle" dominant-baseline="central">'
-        f"{escape(label)}</text>\n"
+        f'rx="{rx}" fill="{fill}" stroke="{stroke}" filter="url(#lift)"/>\n'
+    )
+    if sub:
+        svg += (
+            f'  <text x="{cx:.1f}" y="{y + h / 2 - 4:.1f}" class="ct" '
+            f'fill="{ink}" text-anchor="middle">{escape(title)}</text>\n'
+            f'  <text x="{cx:.1f}" y="{y + h / 2 + 17:.1f}" class="cs" '
+            f'fill="{p["card_sub"]}" text-anchor="middle">{escape(sub)}</text>\n'
+        )
+    else:
+        svg += (
+            f'  <text x="{cx:.1f}" y="{y + h / 2 + 6:.1f}" class="ct" '
+            f'fill="{ink}" text-anchor="middle">{escape(title)}</text>\n'
+        )
+    return svg
+
+
+def _curve(x1, y1, x2, y2, stroke, width=2.0, opacity=0.62, bend=0.55):
+    """A vertical S between two points.
+
+    Control points sit straight above and below their anchors, so a set of
+    curves whose endpoints are both left-to-right ordered can never cross.
+    """
+    dy = (y2 - y1) * bend
+    return (
+        f'  <path d="M {x1:.1f} {y1:.1f} C {x1:.1f} {y1 + dy:.1f}, '
+        f'{x2:.1f} {y2 - dy:.1f}, {x2:.1f} {y2:.1f}" fill="none" '
+        f'stroke="{stroke}" stroke-width="{width}" stroke-linecap="round" '
+        f'opacity="{opacity}"/>\n'
     )
 
 
-def _label(x, y, label, fill, size=10, anchor="middle", weight=600, spacing=1.7):
+def _label(x, y, text, p, anchor="middle"):
     return (
-        f'  <text x="{x:.1f}" y="{y:.1f}" fill="{fill}" font-size="{size}" '
-        f'font-weight="{weight}" letter-spacing="{spacing}" text-anchor="{anchor}">'
-        f"{escape(label)}</text>\n"
-    )
-
-
-def _note(x, y, label, fill, size=11.5, anchor="middle"):
-    return (
-        f'  <text x="{x:.1f}" y="{y:.1f}" fill="{fill}" font-size="{size}" '
-        f'text-anchor="{anchor}">{escape(label)}</text>\n'
-    )
-
-
-def _line(x1, y1, x2, y2, stroke, arrow=False):
-    head = ' marker-end="url(#arrow)"' if arrow else ""
-    return (
-        f'  <path d="M {x1:.1f} {y1:.1f} L {x2:.1f} {y2:.1f}" stroke="{stroke}" '
-        f'stroke-width="1.5" fill="none" stroke-linecap="round"{head}/>\n'
+        f'  <text x="{x:.1f}" y="{y:.1f}" class="lb" fill="{p["label"]}" '
+        f'text-anchor="{anchor}">{escape(text)}</text>\n'
     )
 
 
@@ -165,155 +215,184 @@ def _line(x1, y1, x2, y2, stroke, arrow=False):
 
 def render(scheme: str) -> str:
     p = PALETTES[scheme]
-    cx = W / 2
-    out = []
+    e0, e1, e2 = p["engine"]
+    f0, f1, f2 = p["flow"]
+    sh_color, sh_op = p["shadow"]
+    gl_color, gl_op = p["engine_glow"]
+    o = []
 
-    out.append(
+    o.append(
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" '
-        f'width="{W}" height="{H}" font-family="{FONT}" role="img" '
-        f'aria-labelledby="title desc">\n'
-        f"  <title id=\"title\">Content's architecture</title>\n"
-        f'  <desc id="desc">Sources — a URL, a file, or text — enter one '
-        f"self-hosted engine that analyzes, plans, runs and delivers. Every "
-        f"client (HomeTube, Studio, Console, the browser extension, the MCP "
-        f"server, the CLI, the SDK and the REST API) sits above the engine and "
-        f"reaches it through the same public contract. Artifacts come out: "
-        f"video, audio, subtitles, transcript, summary, translation, chapters "
-        f"and PDF.</desc>\n"
+        f'width="{W}" height="{H}" role="img" aria-labelledby="t d">\n'
+        f'  <title id="t">Content\'s architecture</title>\n'
+        f'  <desc id="d">Sources — a URL, a file, or text — feed one '
+        f"self-hosted Content engine that analyzes, plans, runs and delivers. "
+        f"HomeTube, Studio, Console, the browser extension, the MCP server, the "
+        f"CLI, the Python SDK and the REST API all sit above the engine and "
+        f"reach it through the same public contract. Artifacts come out: video, "
+        f"audio, subtitles, transcript, summary, translation, chapters and "
+        f"PDF.</desc>\n"
         f"  <defs>\n"
-        f'    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" '
-        f'markerWidth="6" markerHeight="6" orient="auto-start-reverse">\n'
-        f'      <path d="M 0 0 L 10 5 L 0 10 z" fill="{p["line"]}"/>\n'
-        f"    </marker>\n"
+        f'    <linearGradient id="eg" x1="0" y1="0" x2="1" y2="1">'
+        f'<stop offset="0%" stop-color="{e0}"/>'
+        f'<stop offset="58%" stop-color="{e1}"/>'
+        f'<stop offset="100%" stop-color="{e2}"/></linearGradient>\n'
+        f'    <linearGradient id="fl" x1="0" y1="0" x2="1" y2="0">'
+        f'<stop offset="0%" stop-color="{f0}"/>'
+        f'<stop offset="45%" stop-color="{f1}"/>'
+        f'<stop offset="100%" stop-color="{f2}"/></linearGradient>\n'
+        f'    <filter id="lift" x="-30%" y="-30%" width="160%" height="180%">'
+        f'<feDropShadow dx="0" dy="6" stdDeviation="11" flood-color="{sh_color}" '
+        f'flood-opacity="{sh_op}"/></filter>\n'
+        f'    <filter id="glow" x="-30%" y="-30%" width="160%" height="180%">'
+        f'<feDropShadow dx="0" dy="12" stdDeviation="22" flood-color="{gl_color}" '
+        f'flood-opacity="{gl_op}"/></filter>\n'
+        f"    <style>\n"
+        f"      text {{ font-family: {FONT}; }}\n"
+        f"      .lb {{ font-size: 15px; font-weight: 700; letter-spacing: .18em; }}\n"
+        # text-anchor stays off these classes on purpose: a class beats the
+        # presentation attribute, so putting it here silently centres every
+        # left-aligned label in the sources column.
+        f"      .ct {{ font-size: 17px; font-weight: 700; }}\n"
+        f"      .cs {{ font-size: 13.5px; font-weight: 500; }}\n"
+        f"    </style>\n"
         f"  </defs>\n"
     )
 
-    # Clients, in a row, converging on one bus rather than eight diagonals.
-    out.append(_label(cx, 22, "CLIENTS", p["muted"]))
-    cw, stride = _row(len(CLIENTS))
-    centers = []
-    for i, name in enumerate(CLIENTS):
-        x = MARGIN + i * stride
-        centers.append(x + cw / 2)
-        out.append(
-            _chip(
-                x,
-                CLIENT_ROW_Y,
-                cw,
-                CHIP_H,
-                name,
-                p["chip_fill"],
-                p["chip_stroke"],
-                p["chip_text"],
-            )
-        )
-    for c in centers:
-        out.append(_line(c, CLIENT_ROW_Y + CHIP_H, c, BUS_Y, p["line"]))
-    out.append(_line(centers[0], BUS_Y, centers[-1], BUS_Y, p["line"]))
-    out.append(_line(cx, BUS_Y, cx, ENGINE["y"] - 6, p["line"], arrow=True))
-    out.append(
-        _note(cx + 12, BUS_Y + 30, "one public contract", p["muted"], 11, "start")
-    )
+    # --- clients, on the shared band -------------------------------------------
+    o.append(_label(AXIS, 30, "CLIENTS", p))
+    cw, cstride = _spread(len(CLIENTS), BAND_X0, BAND_X1, GAP)
+    client_cx = []
+    for i, (name, sub) in enumerate(CLIENTS):
+        x = BAND_X0 + i * cstride
+        client_cx.append(x + cw / 2)
+        o.append(_card(x, CLIENT_Y, cw, CLIENT_H, name, sub, p))
 
-    # Sources, entering from the left.
-    mid = ENGINE["y"] + ENGINE["h"] / 2
-    src_cx = SOURCE_X + SOURCE_W / 2
-    block = len(SOURCES) * SOURCE_H + (len(SOURCES) - 1) * 8
+    # No badge on HomeTube. A 64px card holding two centred lines has no free
+    # corner, and a mark placed anyway lands on top of the word it decorates.
+
+    # Each client lands on its own point along the engine's top edge, in the
+    # same order it sits in the row — a fan, not a knot.
+    land0, land1 = BAND_X0 + 90, BAND_X1 - 90
+    for i, cx in enumerate(client_cx):
+        lx = land0 + i * (land1 - land0) / (len(client_cx) - 1)
+        o.append(_curve(cx, CLIENT_Y + CLIENT_H, lx, ENGINE_Y, "url(#fl)"))
+
+    # --- sources, the only thing off the axis ----------------------------------
+    mid = ENGINE_Y + ENGINE_H / 2
+    block = len(SOURCES) * SOURCE_H + (len(SOURCES) - 1) * SOURCE_GAP
     top = mid - block / 2
-    out.append(_label(src_cx, top - 16, "SOURCES", p["muted"]))
-    for i, name in enumerate(SOURCES):
-        out.append(
-            _chip(
-                SOURCE_X,
-                top + i * (SOURCE_H + 8),
-                SOURCE_W,
-                SOURCE_H,
-                name,
-                p["chip_fill"],
-                p["chip_stroke"],
-                p["chip_text"],
-                size=12,
-            )
+    o.append(_label(SOURCE_X + 4, top - 22, "SOURCES", p, anchor="start"))
+    for i, (name, sub) in enumerate(SOURCES):
+        y = top + i * (SOURCE_H + SOURCE_GAP)
+        o.append(
+            f'  <rect x="{SOURCE_X}" y="{y:.1f}" width="{SOURCE_W}" '
+            f'height="{SOURCE_H}" rx="17" fill="{p["card_fill"]}" '
+            f'stroke="{p["card_stroke"]}" filter="url(#lift)"/>\n'
+            f'  <g transform="translate({SOURCE_X + 34},{y + SOURCE_H / 2:.1f})">\n'
+            f'    <circle r="13" fill="{p["icon_fill"]}" '
+            f'stroke="{p["icon_stroke"]}"/>\n'
+            f'    <path d="{SOURCE_ICONS[name]}" fill="none" '
+            f'stroke="{p["icon_ink"]}" stroke-width="1.4" stroke-linecap="round" '
+            f'stroke-linejoin="round"/>\n'
+            f"  </g>\n"
+            f'  <text x="{SOURCE_X + 60}" y="{y + SOURCE_H / 2 - 4:.1f}" '
+            f'class="ct" fill="{p["card_title"]}" text-anchor="start">'
+            f"{escape(name)}</text>\n"
+            f'  <text x="{SOURCE_X + 60}" y="{y + SOURCE_H / 2 + 16:.1f}" '
+            f'class="cs" fill="{p["card_sub"]}" text-anchor="start">'
+            f"{escape(sub)}</text>\n"
         )
-    # A spine, not a single arrow off the middle chip: drawn straight, the
-    # arrow left of the engine lines up with "a file" and reads as though the
-    # other two go nowhere. Same manifold as the clients, for the same reason.
-    spine = SOURCE_X + SOURCE_W + 18
-    for i in range(len(SOURCES)):
-        y = top + i * (SOURCE_H + 8) + SOURCE_H / 2
-        out.append(_line(SOURCE_X + SOURCE_W, y, spine, y, p["line"]))
-    out.append(_line(spine, top + SOURCE_H / 2, spine, mid + block / 2 - SOURCE_H / 2, p["line"]))
-    out.append(_line(spine, mid, ENGINE["x"] - 6, mid, p["line"], arrow=True))
-
-    # The engine.
-    out.append(
-        f'  <rect x="{ENGINE["x"]}" y="{ENGINE["y"]}" width="{ENGINE["w"]}" '
-        f'height="{ENGINE["h"]}" rx="{ENGINE["rx"]}" fill="{p["engine_fill"]}" '
-        f'stroke="{p["engine_stroke"]}"/>\n'
-    )
-    out.append(
-        f'  <text x="{cx}" y="{ENGINE["y"] + 34}" fill="{p["engine_text"]}" '
-        f'font-size="20" font-weight="650" text-anchor="middle">Content engine</text>\n'
-    )
-    out.append(
-        _note(
-            cx,
-            ENGINE["y"] + 56,
-            "self-hosted · the only business logic",
-            p["engine_sub"],
-        )
-    )
-    pw, pstride = (ENGINE["w"] - 48 - 12 * (len(STEPS) - 1)) / len(STEPS), 0
-    pstride = pw + 12
-    for i, step in enumerate(STEPS):
-        out.append(
-            _chip(
-                ENGINE["x"] + 24 + i * pstride,
-                ENGINE["y"] + 78,
-                pw,
-                32,
-                step,
-                p["pill_fill"],
-                p["pill_stroke"],
-                p["pill_text"],
-                size=12,
-                rx=8,
-            )
+        # A horizontal S into the engine's left edge, spread over its height so
+        # three sources do not all point at the same spot.
+        ty = mid + (i - 1) * 34
+        o.append(
+            f'  <path d="M {SOURCE_X + SOURCE_W + 6} {y + SOURCE_H / 2:.1f} '
+            f"C {SOURCE_X + SOURCE_W + 56} {y + SOURCE_H / 2:.1f}, "
+            f'{BAND_X0 - 56} {ty:.1f}, {BAND_X0 - 12} {ty:.1f}" fill="none" '
+            f'stroke="{p["label"]}" stroke-width="2" stroke-linecap="round" '
+            f'opacity="0.6"/>\n'
+            f'  <path d="M {BAND_X0 - 2} {ty:.1f} l-11 -5.5 v11 z" '
+            f'fill="{p["label"]}" opacity="0.6"/>\n'
         )
 
-    # Artifacts, coming out at the bottom.
-    out.append(
-        _line(cx, ENGINE["y"] + ENGINE["h"], cx, ARTIFACT_ROW_Y - 28, p["line"], True)
+    # --- the engine ------------------------------------------------------------
+    ew = BAND_X1 - BAND_X0
+    o.append(
+        f'  <rect x="{BAND_X0}" y="{ENGINE_Y}" width="{ew}" height="{ENGINE_H}" '
+        f'rx="{ENGINE_R}" fill="url(#eg)" filter="url(#glow)"/>\n'
+        f'  <text x="{AXIS:.1f}" y="{ENGINE_Y + 62}" text-anchor="middle" '
+        f'fill="#ffffff" font-size="36" font-weight="800" '
+        f'letter-spacing="-0.02em">Content engine</text>\n'
+        f'  <text x="{AXIS:.1f}" y="{ENGINE_Y + 92}" text-anchor="middle" '
+        f'fill="#dbeafe" font-size="16" font-weight="500">'
+        f"{escape(ENGINE_SUB)}</text>\n"
     )
-    out.append(
-        _note(
-            cx + 12,
-            ENGINE["y"] + ENGINE["h"] + 26,
-            "delivered where you want them",
-            p["muted"],
-            11,
-            "start",
+
+    # Two badges: what every client shares, and what the engine does with them.
+    bw, bstride = _spread(len(BADGES), BAND_X0 + 76, BAND_X1 - 76, 20)
+    for i, badge in enumerate(BADGES):
+        bx = BAND_X0 + 76 + i * bstride
+        o.append(
+            f'  <rect x="{bx:.1f}" y="{ENGINE_Y + 108}" width="{bw:.1f}" '
+            f'height="34" rx="17" fill="#ffffff" fill-opacity="0.10" '
+            f'stroke="#ffffff" stroke-opacity="0.22"/>\n'
         )
+        for d, colour in enumerate(("#86efac", "#93c5fd", "#c4b5fd")[: 1 if i == 0 else 3]):
+            o.append(
+                f'  <circle cx="{bx + 22 + d * 15:.1f}" cy="{ENGINE_Y + 125}" '
+                f'r="4.5" fill="{colour}"/>\n'
+            )
+        o.append(
+            f'  <text x="{bx + bw / 2 + 14:.1f}" y="{ENGINE_Y + 130}" '
+            f'text-anchor="middle" fill="#eef2ff" font-size="13.5" '
+            f'font-weight="700">{escape(badge)}</text>\n'
+        )
+
+    # The four stages, joined so they read as a sequence rather than a menu.
+    sw, sstride = _spread(len(STEPS), BAND_X0 + 44, BAND_X1 - 44, 22)
+    sy = ENGINE_Y + 164
+    for i, (name, sub) in enumerate(STEPS):
+        sx = BAND_X0 + 44 + i * sstride
+        o.append(
+            f'  <rect x="{sx:.1f}" y="{sy}" width="{sw:.1f}" height="94" rx="20" '
+            f'fill="#ffffff" fill-opacity="0.11" stroke="#ffffff" '
+            f'stroke-opacity="0.22"/>\n'
+            f'  <text x="{sx + sw / 2:.1f}" y="{sy + 42}" text-anchor="middle" '
+            f'fill="#ffffff" font-size="17" font-weight="700">'
+            f"{escape(name)}</text>\n"
+            f'  <text x="{sx + sw / 2:.1f}" y="{sy + 65}" text-anchor="middle" '
+            f'fill="#dce7ff" font-size="13">{escape(sub)}</text>\n'
+        )
+        if i:
+            o.append(
+                f'  <path d="M {sx - 22:.1f} {sy + 47} H {sx:.1f}" '
+                f'stroke="#dce7ff" stroke-width="2" opacity="0.7"/>\n'
+            )
+
+    # --- artifacts -------------------------------------------------------------
+    o.append(
+        f'  <path d="M {AXIS:.1f} {ENGINE_Y + ENGINE_H} V {FAN_Y - 46:.1f}" '
+        f'stroke="{p["arrow"]}" stroke-width="3.4" stroke-linecap="round" '
+        f'fill="none"/>\n'
+        f'  <path d="M {AXIS:.1f} {FAN_Y - 34:.1f} l-8 -13 h16 z" '
+        f'fill="{p["arrow"]}"/>\n'
     )
-    out.append(_label(cx, ARTIFACT_ROW_Y - 12, "ARTIFACTS", p["muted"]))
-    aw, astride = _row(len(ARTIFACTS))
+    # The label sits above where the fan opens, not inside it.
+    o.append(_label(AXIS, FAN_Y - 12, "ARTIFACTS", p))
+    aw, astride = _spread(len(ARTIFACTS), BAND_X0 - 320, BAND_X1, GAP)
     for i, name in enumerate(ARTIFACTS):
-        out.append(
-            _chip(
-                MARGIN + i * astride,
-                ARTIFACT_ROW_Y,
-                aw,
-                CHIP_H,
-                name,
-                p["out_fill"],
-                p["out_stroke"],
-                p["out_text"],
-            )
-        )
-    out.append(_note(cx, ARTIFACT_ROW_Y + CHIP_H + 22, ALSO, p["muted"], 11))
+        x = BAND_X0 - 320 + i * astride
+        o.append(_curve(AXIS, FAN_Y, x + aw / 2, ARTIFACT_Y, "url(#fl)", 1.6, 0.45))
+        o.append(_card(x, ARTIFACT_Y, aw, ARTIFACT_H, name, "", p, out=True))
+    o.append(
+        f'  <text x="{AXIS:.1f}" y="{ARTIFACT_Y + ARTIFACT_H + 34}" '
+        f'text-anchor="middle" fill="{p["label"]}" font-size="13.5" '
+        f'font-weight="600">{escape(ALSO)}</text>\n'
+    )
 
-    out.append("</svg>\n")
-    return "".join(out)
+    o.append("</svg>\n")
+    return "".join(o)
 
 
 def main() -> None:

--- a/tests/test_readme_diagram.py
+++ b/tests/test_readme_diagram.py
@@ -46,8 +46,12 @@ def test_both_schemes_carry_the_same_words():
         for scheme, target in TARGETS.items()
     }
     assert texts["light"] == texts["dark"]
-    for name in (*CLIENTS, *SOURCES, *ARTIFACTS):
-        assert name in texts["light"], f"{name} is drawn nowhere"
+    drawn = set(texts["light"])
+    for name, sub in (*CLIENTS, *SOURCES):
+        assert name in drawn, f"{name} is drawn nowhere"
+        assert sub in drawn, f"{name} has lost its subtitle"
+    for name in ARTIFACTS:
+        assert name in drawn, f"{name} is drawn nowhere"
 
 
 def test_no_chip_escapes_the_canvas():


### PR DESCRIPTION
**Preview:** [github.com/LatentNoise/content/tree/readme-diagram-v2](https://github.com/LatentNoise/content/tree/readme-diagram-v2) — flip your GitHub theme while you're there.

Your ChatGPT version was better than mine in the ways that matter, and three of its ideas are taken wholesale:

- **Curves instead of a comb of right angles.** The straight bus said *protocol diagram*; a curve says something moves along it, which is what a reader should feel about a job.
- **A second line under every name.** HomeTube is a *YouTube UI*, the MCP server is *for agents*, the CLI is a *terminal*. A row of eight nouns means nothing to someone meeting the project; eight nouns with a role each is a map. Same for the stages, and for the sources — "one or a collection" rather than bare "URL".
- **A gradient engine carrying the two things worth promoting into it** — one public contract, independent persistent jobs — instead of a flat block with one line of prose.

## What I changed on the way in

**The structural fault, which explains the tangle in the middle.** Everything below the client row was centred on x=890 while the client row was centred on x=800. The eight curves then had to sweep left across the canvas to correct 90px of offset, crossing the source arrows on the way. Now clients, engine and artifacts share **one axis and one band of width**, and only the sources hang off to the left — because only they are upstream. Each client lands on its own point along the engine's top edge in the order it sits in the row, so the fan is a fan rather than a knot.

**Three smaller ones:**

- The `ARTIFACTS` label sat *inside* the fan it labelled (label at y=600, fan opening at y=575). It now sits above where the fan opens.
- The play mark on HomeTube landed on top of the word "HomeTube". A 64px card holding two centred lines has no free corner, so it's gone rather than nudged.
- `text-anchor` moved out of the CSS classes onto the elements. **A class beats a presentation attribute**, so every left-aligned label in the sources column was being silently centred underneath its own icon.

**And sizing.** I rendered at the width a README actually gets — about 890px — rather than at full canvas. A 1600px canvas puts its 13px captions at 7px there and nobody reads those. Canvas is 1280 now, with the secondary text nudged up after looking at it at true scale.

## Still generated

Both files come from one geometry and one word list (`make readme-diagram`), so a ninth client can't appear in only one theme. The guard gained a check that a **subtitle** can't go missing from one scheme either — I confirmed it's not vacuous by hand-editing "Terminal" to "Terminaal" in the dark file: two tests fail.

Verified as images in both schemes, the dark one against GitHub's own background rather than on white. `make validate` green.

Your original is safe — I didn't overwrite it, and `architecture-light-v2.svg` is removed from `docs/assets/` only because `.gitignore` now un-ignores that folder and it would otherwise sit in `git status` forever.