### PR TITLE
Sources, plural — and a caption so the plural does not over-promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/architecture-dark.svg">
   <img src="docs/assets/architecture-light.svg" width="100%"
-       alt="Sources — a URL, a file, or text — enter one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Out come video, audio, subtitles, transcript, summary, translation, chapters and PDF.">
+       alt="Sources — URLs, files, or texts, several of them in a single job — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Out come video, audio, subtitles, transcript, summary, translation, chapters and PDF.">
 </picture>
 
 </div>

--- a/docs/assets/architecture-dark.svg
+++ b/docs/assets/architecture-dark.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 772" width="1280" height="772" role="img" aria-labelledby="t d">
   <title id="t">Content's architecture</title>
-  <desc id="d">Sources — a URL, a file, or text — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+  <desc id="d">Sources — URLs, files, or texts, several of them in a single job — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
   <defs>
     <linearGradient id="eg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#1f6feb"/><stop offset="58%" stop-color="#4f46e5"/><stop offset="100%" stop-color="#8957e5"/></linearGradient>
     <linearGradient id="fl" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#3fb950"/><stop offset="45%" stop-color="#58a6ff"/><stop offset="100%" stop-color="#a371f7"/></linearGradient>
@@ -52,8 +52,8 @@
     <circle r="13" fill="#0d1f14" stroke="#238636"/>
     <path d="M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="267.0" class="ct" fill="#e6edf3" text-anchor="start">URL</text>
-  <text x="100" y="287.0" class="cs" fill="#8b949e" text-anchor="start">one or a collection</text>
+  <text x="100" y="267.0" class="ct" fill="#e6edf3" text-anchor="start">URLs</text>
+  <text x="100" y="287.0" class="cs" fill="#8b949e" text-anchor="start">one, many, or a playlist</text>
   <path d="M 286 271.0 C 336 271.0, 304 315.0, 348 315.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 315.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
   <rect x="40" y="318.0" width="240" height="62" rx="17" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
@@ -61,8 +61,8 @@
     <circle r="13" fill="#0d1f14" stroke="#238636"/>
     <path d="M-5 -6h7l4 4v8h-11z M2 -6v4h4" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="345.0" class="ct" fill="#e6edf3" text-anchor="start">File</text>
-  <text x="100" y="365.0" class="cs" fill="#8b949e" text-anchor="start">one or many</text>
+  <text x="100" y="345.0" class="ct" fill="#e6edf3" text-anchor="start">Files</text>
+  <text x="100" y="365.0" class="cs" fill="#8b949e" text-anchor="start">one or many, uploaded</text>
   <path d="M 286 349.0 C 336 349.0, 304 349.0, 348 349.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 349.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
   <rect x="40" y="396.0" width="240" height="62" rx="17" fill="#161b22" stroke="#30363d" filter="url(#lift)"/>
@@ -70,10 +70,11 @@
     <circle r="13" fill="#0d1f14" stroke="#238636"/>
     <path d="M-6 -4h12 M-6 0h9 M-6 4h7" fill="none" stroke="#3fb950" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="423.0" class="ct" fill="#e6edf3" text-anchor="start">Text</text>
-  <text x="100" y="443.0" class="cs" fill="#8b949e" text-anchor="start">single or batched</text>
+  <text x="100" y="423.0" class="ct" fill="#e6edf3" text-anchor="start">Texts</text>
+  <text x="100" y="443.0" class="cs" fill="#8b949e" text-anchor="start">pasted or batched</text>
   <path d="M 286 427.0 C 336 427.0, 304 383.0, 348 383.0" fill="none" stroke="#8b949e" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 383.0 l-11 -5.5 v11 z" fill="#8b949e" opacity="0.6"/>
+  <text x="44" y="484.0" class="cs" fill="#8b949e" text-anchor="start">several in a single job</text>
   <rect x="360" y="196" width="880" height="306" rx="44" fill="url(#eg)" filter="url(#glow)"/>
   <text x="800.0" y="258" text-anchor="middle" fill="#ffffff" font-size="36" font-weight="800" letter-spacing="-0.02em">Content engine</text>
   <text x="800.0" y="288" text-anchor="middle" fill="#dbeafe" font-size="16" font-weight="500">self-hosted · persistent · all business logic lives here</text>

--- a/docs/assets/architecture-light.svg
+++ b/docs/assets/architecture-light.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 772" width="1280" height="772" role="img" aria-labelledby="t d">
   <title id="t">Content's architecture</title>
-  <desc id="d">Sources — a URL, a file, or text — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
+  <desc id="d">Sources — URLs, files, or texts, several of them in a single job — feed one self-hosted Content engine that analyzes, plans, runs and delivers. HomeTube, Studio, Console, the browser extension, the MCP server, the CLI, the Python SDK and the REST API all sit above the engine and reach it through the same public contract. Artifacts come out: video, audio, subtitles, transcript, summary, translation, chapters and PDF.</desc>
   <defs>
     <linearGradient id="eg" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#2563eb"/><stop offset="58%" stop-color="#4f46e5"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient>
     <linearGradient id="fl" x1="0" y1="0" x2="1" y2="0"><stop offset="0%" stop-color="#22c55e"/><stop offset="45%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#7c3aed"/></linearGradient>
@@ -52,8 +52,8 @@
     <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
     <path d="M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="267.0" class="ct" fill="#172033" text-anchor="start">URL</text>
-  <text x="100" y="287.0" class="cs" fill="#64748b" text-anchor="start">one or a collection</text>
+  <text x="100" y="267.0" class="ct" fill="#172033" text-anchor="start">URLs</text>
+  <text x="100" y="287.0" class="cs" fill="#64748b" text-anchor="start">one, many, or a playlist</text>
   <path d="M 286 271.0 C 336 271.0, 304 315.0, 348 315.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 315.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
   <rect x="40" y="318.0" width="240" height="62" rx="17" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
@@ -61,8 +61,8 @@
     <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
     <path d="M-5 -6h7l4 4v8h-11z M2 -6v4h4" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="345.0" class="ct" fill="#172033" text-anchor="start">File</text>
-  <text x="100" y="365.0" class="cs" fill="#64748b" text-anchor="start">one or many</text>
+  <text x="100" y="345.0" class="ct" fill="#172033" text-anchor="start">Files</text>
+  <text x="100" y="365.0" class="cs" fill="#64748b" text-anchor="start">one or many, uploaded</text>
   <path d="M 286 349.0 C 336 349.0, 304 349.0, 348 349.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 349.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
   <rect x="40" y="396.0" width="240" height="62" rx="17" fill="#ffffff" stroke="#d7dee9" filter="url(#lift)"/>
@@ -70,10 +70,11 @@
     <circle r="13" fill="#ecfdf5" stroke="#a7f3d0"/>
     <path d="M-6 -4h12 M-6 0h9 M-6 4h7" fill="none" stroke="#16a34a" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
-  <text x="100" y="423.0" class="ct" fill="#172033" text-anchor="start">Text</text>
-  <text x="100" y="443.0" class="cs" fill="#64748b" text-anchor="start">single or batched</text>
+  <text x="100" y="423.0" class="ct" fill="#172033" text-anchor="start">Texts</text>
+  <text x="100" y="443.0" class="cs" fill="#64748b" text-anchor="start">pasted or batched</text>
   <path d="M 286 427.0 C 336 427.0, 304 383.0, 348 383.0" fill="none" stroke="#64748b" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
   <path d="M 358 383.0 l-11 -5.5 v11 z" fill="#64748b" opacity="0.6"/>
+  <text x="44" y="484.0" class="cs" fill="#64748b" text-anchor="start">several in a single job</text>
   <rect x="360" y="196" width="880" height="306" rx="44" fill="url(#eg)" filter="url(#glow)"/>
   <text x="800.0" y="258" text-anchor="middle" fill="#ffffff" font-size="36" font-weight="800" letter-spacing="-0.02em">Content engine</text>
   <text x="800.0" y="288" text-anchor="middle" fill="#dbeafe" font-size="16" font-weight="500">self-hosted · persistent · all business logic lives here</text>

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -51,10 +51,16 @@ CLIENTS = (
     ("REST API", "Anything"),
 )
 SOURCES = (
-    ("URL", "one or a collection"),
-    ("File", "one or many"),
-    ("Text", "single or batched"),
+    ("URLs", "one, many, or a playlist"),
+    ("Files", "one or many, uploaded"),
+    ("Texts", "pasted or batched"),
 )
+# Plural, because `sources` is an array and a single job really does carry
+# several — verified: three sources each with their own outputs validates. The
+# caption is there to stop the plural over-claiming: an output consuming two
+# sources at once is refused (`too_many_inputs`), so the promise is "many
+# sources in one job", not "many sources merged into one file".
+SOURCES_NOTE = "several in a single job"
 STEPS = (
     ("Analyze", "understand"),
     ("Plan", "resolve the path"),
@@ -148,9 +154,9 @@ PALETTES = {
 # Little marks that say what a source *is* without a word. Drawn at the origin
 # and translated into place, so the icon and its chip cannot drift apart.
 SOURCE_ICONS = {
-    "URL": "M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12",
-    "File": "M-5 -6h7l4 4v8h-11z M2 -6v4h4",
-    "Text": "M-6 -4h12 M-6 0h9 M-6 4h7",
+    "URLs": "M-6 0h12 M0 -6c-3 3 -3 9 0 12 M0 -6c3 3 3 9 0 12",
+    "Files": "M-5 -6h7l4 4v8h-11z M2 -6v4h4",
+    "Texts": "M-6 -4h12 M-6 0h9 M-6 4h7",
 }
 
 
@@ -225,8 +231,9 @@ def render(scheme: str) -> str:
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" '
         f'width="{W}" height="{H}" role="img" aria-labelledby="t d">\n'
         f'  <title id="t">Content\'s architecture</title>\n'
-        f'  <desc id="d">Sources — a URL, a file, or text — feed one '
-        f"self-hosted Content engine that analyzes, plans, runs and delivers. "
+        f'  <desc id="d">Sources — URLs, files, or texts, several of them in '
+        f"a single job — feed one self-hosted Content engine that analyzes, "
+        f"plans, runs and delivers. "
         f"HomeTube, Studio, Console, the browser extension, the MCP server, the "
         f"CLI, the Python SDK and the REST API all sit above the engine and "
         f"reach it through the same public contract. Artifacts come out: video, "
@@ -315,6 +322,10 @@ def render(scheme: str) -> str:
             f'  <path d="M {BAND_X0 - 2} {ty:.1f} l-11 -5.5 v11 z" '
             f'fill="{p["label"]}" opacity="0.6"/>\n'
         )
+    o.append(
+        f'  <text x="{SOURCE_X + 4}" y="{top + block + 26:.1f}" class="cs" '
+        f'fill="{p["label"]}" text-anchor="start">{escape(SOURCES_NOTE)}</text>\n'
+    )
 
     # --- the engine ------------------------------------------------------------
     ew = BAND_X1 - BAND_X0


### PR DESCRIPTION
**Preview:** [github.com/LatentNoise/content/tree/readme-diagram-plural-sources](https://github.com/LatentNoise/content/tree/readme-diagram-plural-sources)

Your suggestion, and the contract backs it — `sources` is an array and a job really does carry several. The chips now read **URLs**, **Files**, **Texts**, with subtitles saying it again: *one, many, or a playlist* · *one or many, uploaded* · *pasted or batched*.

## I checked before claiming it

| | result |
| --- | --- |
| Three sources, each with its own output, one request | **valid** |
| One output naming two sources | **refused** — `too_many_inputs` |

> "A summary consumes exactly one input (one source or one upstream output)."

The planner skips any output whose resolved sources aren't exactly one (`planner.py:430`, `:2175`), and `validate_structure` refuses it before that.

## Which is why the plural needed a sentence next to it

On its own, three plural nouns pointing at one engine invite the reading that Content **merges** several sources into one file. It doesn't, and it shouldn't pretend to. So there's a caption under the column — **"several in a single job"** — saying the true version: many sources, each producing its own artifacts, in one run.

The accessible `<desc>` and the README's `alt` moved with the picture. They're the only version of this diagram a screen reader gets, and a caption that exists only in the drawing is one half the readers never see.

`make validate` green, both schemes regenerated from the one word list.