### PR TITLE
Several sources is well-formed, and the engine now says so

### DIFF
--- a/apps/backend/content/domain/validation.py
+++ b/apps/backend/content/domain/validation.py
@@ -18,6 +18,14 @@ from content.domain.reserved import check_reserved
 # V1 media output types consume exactly one source and no upstream outputs.
 _SINGLE_SOURCE_TYPES = ("video", "audio", "metadata", "thumbnail", "subtitles")
 
+# The scopes under which one output instance takes one source, and where an
+# arity rule is therefore the engine's to enforce. `each_item` belongs here:
+# it fans over the members of *one* collection source (ADR 0019). Every other
+# scope is about several sources by definition, so the number of inputs is the
+# planner's business — and the planner's answer for all of them today is
+# `scope_not_supported`, which is a promise rather than a rejection.
+_ONE_INSTANCE_SCOPES = ("single", "each_item")
+
 
 class ResolvedInputs(dict):
     """output id -> (source_ids, output_ids) once resolution rules applied."""
@@ -143,6 +151,17 @@ def validate_structure(request: GenerationRequest) -> ValidationResult:
     issues.extend(resolution_issues)
 
     for index, output in enumerate(request.outputs):
+        # Both arity rules below describe **one instance consuming one input**,
+        # which is a property of the scope and not of the output type — the
+        # second one's own message has always said "with scope 'single'".
+        # Applied to every scope, they made the documented answer unreachable:
+        # a client asking for `all_sources`, the scope whose entire purpose is
+        # aggregating several sources, was told `too_many_inputs` — that its
+        # request was malformed — instead of `scope_not_supported`, that it was
+        # well-formed and simply not implemented yet. Those are different
+        # answers, and only the second one tells a client to come back later.
+        if output.scope not in _ONE_INSTANCE_SCOPES:
+            continue
         if output.type in ("transcript", "summary", "translation", "chapters"):
             # These derive from exactly one input: a source, or one upstream
             # output (transcript <- subtitles/audio; summary <- transcript;

--- a/apps/backend/tests/test_contract_validation.py
+++ b/apps/backend/tests/test_contract_validation.py
@@ -271,3 +271,56 @@ def test_no_public_field_is_accepted_without_being_classified():
         f"reserved: {sorted(unclassified)} — read them in the engine, or add "
         "them to content/domain/reserved.py with a refusal or a warning"
     )
+
+
+# --- multi-source scopes answer "not yet", not "malformed" ----------------------
+
+
+def _two_source_payload(**output):
+    return {
+        "schema_version": "1.0",
+        "sources": [
+            {"id": "a", "type": "text", "content": "one"},
+            {"id": "b", "type": "text", "content": "two"},
+        ],
+        "outputs": [{"id": "s", "from_sources": ["a", "b"], **output}],
+    }
+
+
+@pytest.mark.parametrize("scope", ["all_sources", "each_source", "group"])
+def test_a_multi_source_scope_is_well_formed(scope):
+    """Content is meant to aggregate several sources; `all_sources` is the
+    scope that says so, and Studio already offers up to eight sources.
+
+    Structural validation used to answer `too_many_inputs` here — *your request
+    is malformed* — because an arity rule written for one instance consuming
+    one source was applied to every scope. That made the documented answer
+    unreachable: the contract promises `scope_not_supported`, "valid but not
+    supported by the current execution engine", and a client cannot tell from
+    `too_many_inputs` that the thing it asked for is coming.
+    """
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope=scope))
+    )
+    assert "too_many_inputs" not in codes_of(result)
+    assert result.valid, codes_of(result)
+
+
+@pytest.mark.parametrize("output_type", ["summary", "transcript", "video", "audio"])
+def test_single_scope_still_takes_exactly_one_source(output_type):
+    """The rule is not gone, it is scoped. One instance still consumes one
+    source, which is what `single` means."""
+    result = validate_structure(
+        make_request(_two_source_payload(type=output_type, scope="single"))
+    )
+    assert "too_many_inputs" in codes_of(result)
+
+
+def test_each_item_still_takes_exactly_one_source():
+    """`each_item` fans over the members of *one* collection (ADR 0019), so it
+    keeps the arity rule — and must not become a silent no-op in the planner,
+    which returns early when the count is not one."""
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope="each_item"))
+    )
+    assert "too_many_inputs" in codes_of(result)

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -163,7 +163,7 @@ and this paragraph is the reservation: a future language code spelled
 1. `from_sources` and `from_outputs` list existing ids; otherwise `unknown_source_reference` / `unknown_output_reference`.
 2. The `from_outputs` graph must be acyclic (`dependency_cycle`).
 3. If both are empty: the output consumes **the single source** of the request if `sources` holds only one; otherwise the `role: primary` source if it is unique; otherwise the error `ambiguous_inputs` ("precise from_sources"). No other inference.
-4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise).
+4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise). **This arity is a property of the scope, not of the type**: it binds `single` and `each_item`, both of which resolve one instance to one source. A scope that is *about* several sources — `each_source`, `all_sources`, `group` — is never `too_many_inputs`; it is well-formed, and today it answers `scope_not_supported`.
 5. A dependency that is declared but technically useless is not an error: it constrains ordering (the step waits) and the provenance. The planner never silently "corrects" the client's declarations.
 
 ### `scope`

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -55,11 +55,13 @@ SOURCES = (
     ("Files", "one or many, uploaded"),
     ("Texts", "pasted or batched"),
 )
-# Plural, because `sources` is an array and a single job really does carry
-# several — verified: three sources each with their own outputs validates. The
-# caption is there to stop the plural over-claiming: an output consuming two
-# sources at once is refused (`too_many_inputs`), so the promise is "many
-# sources in one job", not "many sources merged into one file".
+# Plural, because `sources` is documented 1..N and a job really does carry
+# several — Studio offers up to eight. The caption bounds the claim to what
+# runs today: several sources, each producing its own artifacts, in one job.
+# Aggregating several sources into one artifact is the `all_sources` scope,
+# which is designed, documented as "one aggregated result (fan-in)", and not
+# yet implemented — so the engine answers `scope_not_supported` rather than
+# refusing the request.
 SOURCES_NOTE = "several in a single job"
 STEPS = (
     ("Analyze", "understand"),


### PR DESCRIPTION
You were right and I was wrong yesterday. Content **is** meant to take several sources — the docs have always said so, and the error was in the code, not the documentation.

## What the documentation already said

- `sources` (required, **1..N**) — contract.md
- `all_sources` — **"one aggregated result (fan-in)"** — domain.md
- Studio: `st.number_input("How many sources?", 1, 8, 1)` — up to eight

## What the engine actually answered

`validate_structure` held two arity rules, both written for *one instance consuming one input*, and both applied to **every** scope. The second one's own message said `"with scope 'single'"` while never checking the scope. The comment above the first named the gap out loud:

> `# Multi-input aggregation belongs to scope all_sources, not implemented.`

So a client asking for `all_sources` — the documented mechanism, with the sources it wants — was told **`too_many_inputs`: your request is malformed.** Which it wasn't.

## Why that matters more than a wrong string

AGENTS.md: *"'Valid but not implemented' (`*_not_supported`) is a different answer than 'invalid'."*

The contract promises `scope_not_supported`, and the planner emits exactly that (`planner.py:2157`). It was simply **unreachable** — `validate_structure` runs at `submit.py:52`, before planning, and rejected the request first. A client could not tell a capability that is *coming* from a request it should stop sending.

## The fix

The arity rule is now bound to the scopes it describes: `single`, and `each_item` (which fans over the members of *one* collection, ADR 0019). Everything else reaches the planner.

Verified end to end — `all_sources` over two sources now returns:

```
scope_not_supported @ outputs[0].scope
  The scope 'all_sources' is valid but is not supported by the current execution engine.
```

**Nothing that runs became permissible.** `single` with two sources is still `too_many_inputs` — for summaries and media types alike — and so is `each_item`. That last one matters: `_plan_each_item` returns early on a count that isn't one, so without the check that early return would be a silent no-op instead of an error. There's a test pinning it.

8 new tests, `make validate` green (784 backend). Contract rule D3.4 gains the sentence that would have prevented this: **the arity is a property of the scope, not of the output type.**

## Still not implemented

`all_sources` aggregation itself. This changes the *answer*, not the capability — but now the answer tells a client to come back rather than to give up.