### PR TITLE
Refresh yt-dlp daily in the tags that already move

### DIFF
--- a/.github/scripts/ytdlp_base_check.py
+++ b/.github/scripts/ytdlp_base_check.py
@@ -225,6 +225,13 @@ def main() -> None:
         with open(output, "a", encoding="utf-8") as handle:
             handle.write(f"update_available={str(not up_to_date).lower()}\n")
             handle.write(f"issue_title={title}\n")
+            # What the refresh workflow builds with. The digest is the
+            # authority — it is what Docker resolves and it is immutable — and
+            # the version is carried alongside so the rebuilt image can still
+            # say, in a label a human reads, which yt-dlp is inside it.
+            handle.write(f"pinned_version={pinned_version}\n")
+            handle.write(f"new_version={new_version}\n")
+            handle.write(f"new_digest={new_digest}\n")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ytdlp-refresh.yml
+++ b/.github/workflows/ytdlp-refresh.yml
@@ -1,0 +1,210 @@
+# Rebuild the current release on a newer yt-dlp, daily, and republish only the
+# tags that already move.
+#
+# yt-dlp is the one dependency that rots without anyone touching this
+# repository: YouTube changes its player, and a downloader that worked last
+# month answers "No video formats found". The failure is total rather than
+# subtle, and it arrives on YouTube's schedule, not on a release schedule. That
+# is why the weekly watcher exists — but a watcher only shortens the time to
+# *notice*. Between noticing and a maintainer cutting a release, the engine
+# stays broken for everybody, and issue #28 spent six weeks in exactly that gap.
+#
+# What makes this safe is a distinction the tag scheme already draws.
+# `X.Y.Z` is what was released and validated; it is never touched here. `latest`,
+# `X.Y` and `X` already move — CI re-points them at every release — and
+# `deploy/docker-compose.yml` defaults to `latest`. So a self-hoster who wants
+# a working downloader follows a moving tag and gets a fresh yt-dlp within a
+# day; one who wants exactly what shipped pins `X.Y.Z` and is unaffected.
+#
+# The source pin is likewise never edited. `docs/operations/ytdlp-base-image.md`
+# keeps its policy — the Dockerfile is bumped by the maintainer after local
+# validation — and this workflow only passes a newer base as a `--build-arg`,
+# which is the escape hatch that document already describes for trying a
+# candidate. The weekly watcher still files its issue, so the deliberate bump
+# still happens; this just stops users waiting for it.
+
+name: Refresh yt-dlp in the published image
+
+on:
+  schedule:
+    # Daily, 05:43 UTC. Off the hour: GitHub drops scheduled runs when the
+    # whole platform stampedes at :00.
+    - cron: "43 5 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Rebuild even if the pinned base is already current"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ytdlp-refresh
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Is the released image carrying a stale yt-dlp?
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      stale: ${{ steps.check.outputs.update_available }}
+      release: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      moving_tags: ${{ steps.release.outputs.moving_tags }}
+      new_version: ${{ steps.check.outputs.new_version }}
+      new_digest: ${{ steps.check.outputs.new_digest }}
+      pinned_version: ${{ steps.check.outputs.pinned_version }}
+    steps:
+      - name: Find the current release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          version="${tag#v}"
+          owner=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          repo="ghcr.io/${owner}/content"
+          # Only the tags CI already re-points at every release. X.Y.Z is what
+          # was validated and is deliberately absent from this list.
+          case "$version" in
+            *-*) echo "A pre-release is not refreshed: $version" >&2; exit 1 ;;
+            *)
+              major="${version%%.*}"
+              minor="${version%.*}"
+              echo "moving_tags=${repo}:latest,${repo}:${minor},${repo}:${major}" >>"$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "Release $tag; moving tags will be re-pointed."
+
+      - name: Check out the released tree, not main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Compare its pin against upstream
+        id: check
+        # The same script the weekly watcher runs, against the *released*
+        # Dockerfile rather than main's — what users are running is what is
+        # being judged.
+        run: python3 .github/scripts/ytdlp_base_check.py
+        env:
+          DOCKERFILE: apps/backend/Dockerfile
+
+  refresh:
+    name: Rebuild ${{ needs.check.outputs.release }} on yt-dlp ${{ needs.check.outputs.new_version }}
+    needs: check
+    if: needs.check.outputs.stale == 'true' || inputs.force
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write # GHCR, via GITHUB_TOKEN — no stored registry secret
+    steps:
+      - name: Check out the released tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.check.outputs.release }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build for a boot check
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: content-refresh-check:local
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          provenance: false
+          sbom: false
+
+      # Nothing is published that could not start and could not download. A
+      # daily unattended publish is only defensible if it is gated on the two
+      # things that actually break: the app failing to construct (0.5.0 shipped
+      # unbootable for exactly this reason) and yt-dlp failing to run.
+      - name: The app must build and yt-dlp must answer
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python content-refresh-check:local \
+            -c 'from content.api.app import create_app; create_app(); print("app ok")'
+          got=$(docker run --rm --entrypoint yt-dlp content-refresh-check:local --version)
+          echo "yt-dlp in the rebuilt image: $got"
+          want="${{ needs.check.outputs.new_version }}"
+          # Upstream writes 2026.08.19, yt-dlp reports 2026.08.19 — but an
+          # untagged candidate leaves `want` empty, and then there is nothing
+          # to compare and nothing to publish.
+          if [ -z "$want" ]; then
+            echo "The upstream digest carries no version tag; not publishing." >&2
+            exit 1
+          fi
+          if [ "$got" != "$want" ]; then
+            echo "Expected yt-dlp $want, image reports $got." >&2
+            exit 1
+          fi
+
+      - name: Publish the moving tags
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.check.outputs.moving_tags }}
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.check.outputs.release }}
+            org.opencontainers.image.revision=${{ needs.check.outputs.release }}
+          provenance: false
+          sbom: false
+
+      # Two different things trigger a rebuild and they are worth different
+      # words, for the same reason the watcher's issue titles are: a new yt-dlp
+      # is how YouTube downloads stop working, a rebuilt base at the same
+      # version is distro patches — which is also worth having, since every
+      # CRITICAL/HIGH finding in Saturday's image scan sat in that layer.
+      - name: Say what moved
+        env:
+          WAS: ${{ needs.check.outputs.pinned_version }}
+          NOW: ${{ needs.check.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          if [ "$WAS" = "$NOW" ]; then
+            what="Base rebuilt at the same yt-dlp ($NOW) — distro patches."
+          else
+            what="New yt-dlp: $WAS → $NOW."
+          fi
+          {
+            echo "### yt-dlp refresh"
+            echo
+            echo "$what"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Release rebuilt | \`${{ needs.check.outputs.release }}\` |"
+            echo "| Tags re-pointed | \`${{ needs.check.outputs.moving_tags }}\` |"
+            echo
+            echo "\`${{ needs.check.outputs.version }}\` was **not** republished:"
+            echo "it is what was released and validated."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/apps/backend/content/domain/validation.py
+++ b/apps/backend/content/domain/validation.py
@@ -18,6 +18,14 @@ from content.domain.reserved import check_reserved
 # V1 media output types consume exactly one source and no upstream outputs.
 _SINGLE_SOURCE_TYPES = ("video", "audio", "metadata", "thumbnail", "subtitles")
 
+# The scopes under which one output instance takes one source, and where an
+# arity rule is therefore the engine's to enforce. `each_item` belongs here:
+# it fans over the members of *one* collection source (ADR 0019). Every other
+# scope is about several sources by definition, so the number of inputs is the
+# planner's business — and the planner's answer for all of them today is
+# `scope_not_supported`, which is a promise rather than a rejection.
+_ONE_INSTANCE_SCOPES = ("single", "each_item")
+
 
 class ResolvedInputs(dict):
     """output id -> (source_ids, output_ids) once resolution rules applied."""
@@ -143,6 +151,17 @@ def validate_structure(request: GenerationRequest) -> ValidationResult:
     issues.extend(resolution_issues)
 
     for index, output in enumerate(request.outputs):
+        # Both arity rules below describe **one instance consuming one input**,
+        # which is a property of the scope and not of the output type — the
+        # second one's own message has always said "with scope 'single'".
+        # Applied to every scope, they made the documented answer unreachable:
+        # a client asking for `all_sources`, the scope whose entire purpose is
+        # aggregating several sources, was told `too_many_inputs` — that its
+        # request was malformed — instead of `scope_not_supported`, that it was
+        # well-formed and simply not implemented yet. Those are different
+        # answers, and only the second one tells a client to come back later.
+        if output.scope not in _ONE_INSTANCE_SCOPES:
+            continue
         if output.type in ("transcript", "summary", "translation", "chapters"):
             # These derive from exactly one input: a source, or one upstream
             # output (transcript <- subtitles/audio; summary <- transcript;

--- a/apps/backend/tests/test_contract_validation.py
+++ b/apps/backend/tests/test_contract_validation.py
@@ -271,3 +271,56 @@ def test_no_public_field_is_accepted_without_being_classified():
         f"reserved: {sorted(unclassified)} — read them in the engine, or add "
         "them to content/domain/reserved.py with a refusal or a warning"
     )
+
+
+# --- multi-source scopes answer "not yet", not "malformed" ----------------------
+
+
+def _two_source_payload(**output):
+    return {
+        "schema_version": "1.0",
+        "sources": [
+            {"id": "a", "type": "text", "content": "one"},
+            {"id": "b", "type": "text", "content": "two"},
+        ],
+        "outputs": [{"id": "s", "from_sources": ["a", "b"], **output}],
+    }
+
+
+@pytest.mark.parametrize("scope", ["all_sources", "each_source", "group"])
+def test_a_multi_source_scope_is_well_formed(scope):
+    """Content is meant to aggregate several sources; `all_sources` is the
+    scope that says so, and Studio already offers up to eight sources.
+
+    Structural validation used to answer `too_many_inputs` here — *your request
+    is malformed* — because an arity rule written for one instance consuming
+    one source was applied to every scope. That made the documented answer
+    unreachable: the contract promises `scope_not_supported`, "valid but not
+    supported by the current execution engine", and a client cannot tell from
+    `too_many_inputs` that the thing it asked for is coming.
+    """
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope=scope))
+    )
+    assert "too_many_inputs" not in codes_of(result)
+    assert result.valid, codes_of(result)
+
+
+@pytest.mark.parametrize("output_type", ["summary", "transcript", "video", "audio"])
+def test_single_scope_still_takes_exactly_one_source(output_type):
+    """The rule is not gone, it is scoped. One instance still consumes one
+    source, which is what `single` means."""
+    result = validate_structure(
+        make_request(_two_source_payload(type=output_type, scope="single"))
+    )
+    assert "too_many_inputs" in codes_of(result)
+
+
+def test_each_item_still_takes_exactly_one_source():
+    """`each_item` fans over the members of *one* collection (ADR 0019), so it
+    keeps the arity rule — and must not become a silent no-op in the planner,
+    which returns early when the count is not one."""
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope="each_item"))
+    )
+    assert "too_many_inputs" in codes_of(result)

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -93,6 +93,27 @@ def _actionable(exc: ContentError, base_url: str) -> str:
     return str(exc)
 
 
+# The SDK draws a line Content already believed in: a failure you *anticipated*
+# is reported with your message, and anything else is a crash whose text is
+# withheld from the model. `ToolError` is how a handler says which one this is.
+#
+# Raising a bare `RuntimeError` put every engine failure on the wrong side of
+# that line: from mcp 2.1 an agent asking about an unreachable engine was told
+# "Error executing tool get_config" and nothing more — no URL, no remedy, which
+# is exactly the answer `_actionable` exists to prevent.
+#
+# Imported defensively because the floor is `mcp>=1.2`: the class moved with
+# the fastmcp-to-mcpserver rename, and on a release that has neither, a plain
+# exception is the old behaviour rather than a crash at import time.
+try:  # mcp >= 2.1
+    from mcp.server.mcpserver.exceptions import ToolError
+except ImportError:  # pragma: no cover - depends on the installed mcp
+    try:  # mcp < 2.1
+        from mcp.server.fastmcp.exceptions import ToolError
+    except ImportError:
+        ToolError = RuntimeError  # type: ignore[assignment, misc]
+
+
 def _friendly(fn, client: ContentClient):
     """Wrap one tool so SDK errors surface as guidance rather than errno."""
 
@@ -101,7 +122,17 @@ def _friendly(fn, client: ContentClient):
         try:
             return fn(*args, **kwargs)
         except ContentError as exc:
-            raise RuntimeError(_actionable(exc, client.base_url)) from exc
+            # Anticipated: the engine answered, and what it answered is the
+            # most useful thing the agent can be told.
+            raise ToolError(_actionable(exc, client.base_url)) from exc
+        except (ValueError, TypeError) as exc:
+            # The service's own rejections of a malformed call — "this output
+            # has no 'type'", with the example that fixes it. Anticipated in
+            # the strongest sense: the message exists precisely so the agent
+            # can correct itself without a round trip to the engine. Translated
+            # here rather than raised as ToolError inside `service`, which has
+            # no business importing the MCP SDK.
+            raise ToolError(str(exc)) from exc
 
     return wrapper
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -163,7 +163,7 @@ and this paragraph is the reservation: a future language code spelled
 1. `from_sources` and `from_outputs` list existing ids; otherwise `unknown_source_reference` / `unknown_output_reference`.
 2. The `from_outputs` graph must be acyclic (`dependency_cycle`).
 3. If both are empty: the output consumes **the single source** of the request if `sources` holds only one; otherwise the `role: primary` source if it is unique; otherwise the error `ambiguous_inputs` ("precise from_sources"). No other inference.
-4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise).
+4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise). **This arity is a property of the scope, not of the type**: it binds `single` and `each_item`, both of which resolve one instance to one source. A scope that is *about* several sources — `each_source`, `all_sources`, `group` — is never `too_many_inputs`; it is well-formed, and today it answers `scope_not_supported`.
 5. A dependency that is declared but technically useless is not an error: it constrains ordering (the step waits) and the provenance. The planner never silently "corrects" the client's declarations.
 
 ### `scope`

--- a/docs/operations/ytdlp-base-image.md
+++ b/docs/operations/ytdlp-base-image.md
@@ -15,12 +15,39 @@ hard, notice automatically, upgrade deliberately.**
 | --- | --- |
 | **Pinned** | An explicit version *and* an immutable digest — never `:latest` |
 | **Detected** | A scheduled workflow compares the pin against upstream every week |
-| **Upgraded** | Only by the maintainer, only after local validation passes |
-| **Never** | No automatic bump, no dependency-update pull request, no auto-merge, no auto-publish |
+| **Upgraded** | The pin in the Dockerfile: only by the maintainer, only after local validation passes |
+| **Refreshed** | The *moving image tags*: daily and unattended, gated on a boot check and a `yt-dlp --version` check |
+| **Never** | No automatic edit to the pin, no auto-merge, and never a republished `X.Y.Z` |
 
-Pull requests are disabled on this repository ([CONTRIBUTING.md](../../CONTRIBUTING.md)),
-so the usual bot-opens-a-PR mechanism is not available and would not be wanted.
-The workflow files **an issue** instead: a notification, not a change.
+The workflow files **an issue** rather than opening a pull request: a
+notification, not a change. Unsolicited pull requests are closed unread
+([CONTRIBUTING.md](../../CONTRIBUTING.md)) — the maintainer's own are the normal
+route for everything else, and Dependabot opens them for pinned actions, but a
+base-image bump wants the local validation below rather than a green tick.
+
+### Why the tags are refreshed and the pin is not
+
+A watcher only shortens the time to *notice*. Between noticing and a release,
+every user's downloader stays broken — issue #28 spent six weeks in that gap,
+and the failure mode is total: "No video formats found", not a degraded result.
+
+What makes an unattended rebuild safe here is a distinction the tag scheme
+already draws. `X.Y.Z` is what was released and validated, and nothing
+republishes it. `latest`, `X.Y` and `X` **already move** — CI re-points them at
+every release, and `deploy/docker-compose.yml` defaults to `latest`. So
+`.github/workflows/ytdlp-refresh.yml` rebuilds the released tree on the newest
+base and re-points only those, which is a promise none of them were making.
+
+The source pin is untouched: the refresh passes the newer base as a
+`--build-arg`, the escape hatch described below. The weekly issue still gets
+filed, and the deliberate bump still happens — this only stops users waiting
+for it.
+
+It also catches something the yt-dlp framing misses. Upstream republishes the
+same yt-dlp version when the distro underneath it is patched, and every
+CRITICAL/HIGH finding in the image scan (ADR 0026) lives in exactly that layer.
+So the trigger is a **digest** change, not a version change, and the run summary
+says which of the two happened.
 
 ## How the pin is written
 

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -55,11 +55,13 @@ SOURCES = (
     ("Files", "one or many, uploaded"),
     ("Texts", "pasted or batched"),
 )
-# Plural, because `sources` is an array and a single job really does carry
-# several — verified: three sources each with their own outputs validates. The
-# caption is there to stop the plural over-claiming: an output consuming two
-# sources at once is refused (`too_many_inputs`), so the promise is "many
-# sources in one job", not "many sources merged into one file".
+# Plural, because `sources` is documented 1..N and a job really does carry
+# several — Studio offers up to eight. The caption bounds the claim to what
+# runs today: several sources, each producing its own artifacts, in one job.
+# Aggregating several sources into one artifact is the `all_sources` scope,
+# which is designed, documented as "one aggregated result (fan-in)", and not
+# yet implemented — so the engine answers `scope_not_supported` rather than
+# refusing the request.
 SOURCES_NOTE = "several in a single job"
 STEPS = (
     ("Analyze", "understand"),

--- a/tests/test_ytdlp_base_check.py
+++ b/tests/test_ytdlp_base_check.py
@@ -49,3 +49,75 @@ def test_the_body_opens_on_the_distinction_too():
     # Both keep the promise the workflow makes: it never edits anything.
     for body in (upgrade, rebuild):
         assert "Nothing has been changed" in body
+
+
+# --- what the refresh workflow builds with -------------------------------------
+
+
+def test_the_check_exposes_what_a_rebuild_needs(tmp_path, monkeypatch):
+    """The daily refresh rebuilds the released tree on the newer base, so it
+    needs the version and the digest the check resolved — not just a boolean.
+
+    The digest is what Docker resolves and is the authority; the version rides
+    along so the rebuilt image can still say, in a label a human reads, which
+    yt-dlp is inside it.
+    """
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.01.01\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    assert written["pinned_version"] == "2026.01.01"
+    assert written["new_version"] == "2026.08.19"
+    assert written["new_digest"] == "sha256:" + "b" * 64
+
+
+def test_a_rebuilt_base_still_reports_its_version(tmp_path, monkeypatch):
+    """Upstream republishes the same yt-dlp when the distro under it is
+    patched. That is a digest change with no version change, it is still worth
+    rebuilding for — the image scan's findings all live in that layer — and the
+    two must stay distinguishable downstream."""
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.08.19\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    # Same version on both sides: the refresh must still be able to tell the
+    # reader this was a rebuild rather than a new yt-dlp.
+    assert written["pinned_version"] == written["new_version"] == "2026.08.19"


### PR DESCRIPTION
Prompt 05: *"shouldn't we auto-update daily like HomeTube does?"* — **yes**, and the reason the current policy said no turns out not to hold.

## The problem a watcher doesn't solve

A watcher shortens the time to *notice*. Between noticing and a release, every user's downloader stays broken — **issue #28 spent six weeks in that gap** — and the failure is total, not degraded: "No video formats found", nothing downloads. yt-dlp rots on YouTube's schedule, not on a release schedule.

## What makes an unattended rebuild safe here

A distinction the tag scheme already draws, and which the policy hadn't noticed it was drawing:

| tag | today | after this |
| --- | --- | --- |
| `X.Y.Z` | frozen at release | **still frozen — never republished** |
| `latest`, `X.Y`, `X` | already re-pointed at every release | re-pointed daily on a newer base |

`deploy/docker-compose.yml` defaults to `latest`. So a self-hoster who wants a working downloader follows a moving tag and gets a fresh yt-dlp within a day; one who wants exactly what shipped pins `X.Y.Z` and is untouched. **No tag makes a promise it wasn't already making.**

The source pin is not edited. The refresh passes the newer base as a `--build-arg` — the escape hatch `ytdlp-base-image.md` already documented for trying a candidate — and the weekly issue is still filed, so your deliberate bump still happens. This only stops users waiting for it.

## A second thing it catches

The trigger is a **digest** change, not a version change. Upstream republishes the same yt-dlp when the distro beneath it is patched — and **every CRITICAL/HIGH finding in Saturday's image scan lives in exactly that layer**. So the job that keeps downloads working also picks up the base-image fixes ADR 0026 could only advise. The run summary says which of the two happened.

## Nothing ships unchecked

The rebuild is gated on the app constructing (0.5.0 shipped unbootable for want of that check) and on `yt-dlp --version` reporting the version that was asked for. An untagged upstream candidate publishes nothing at all.

## Also corrected

`ytdlp-base-image.md` claimed *"pull requests are disabled on this repository"*. That's an over-reading of CONTRIBUTING.md, which closes **unsolicited** ones and says plainly that GitHub offers no way to disable them — and Dependabot has been opening them here since Saturday.

`make validate` green, 2 new tests on the check script's new outputs.