### PR TITLE
Content can read its own output aloud

### DIFF
--- a/.github/scripts/ytdlp_base_check.py
+++ b/.github/scripts/ytdlp_base_check.py
@@ -225,6 +225,13 @@ def main() -> None:
         with open(output, "a", encoding="utf-8") as handle:
             handle.write(f"update_available={str(not up_to_date).lower()}\n")
             handle.write(f"issue_title={title}\n")
+            # What the refresh workflow builds with. The digest is the
+            # authority — it is what Docker resolves and it is immutable — and
+            # the version is carried alongside so the rebuilt image can still
+            # say, in a label a human reads, which yt-dlp is inside it.
+            handle.write(f"pinned_version={pinned_version}\n")
+            handle.write(f"new_version={new_version}\n")
+            handle.write(f"new_digest={new_digest}\n")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ytdlp-refresh.yml
+++ b/.github/workflows/ytdlp-refresh.yml
@@ -1,0 +1,210 @@
+# Rebuild the current release on a newer yt-dlp, daily, and republish only the
+# tags that already move.
+#
+# yt-dlp is the one dependency that rots without anyone touching this
+# repository: YouTube changes its player, and a downloader that worked last
+# month answers "No video formats found". The failure is total rather than
+# subtle, and it arrives on YouTube's schedule, not on a release schedule. That
+# is why the weekly watcher exists — but a watcher only shortens the time to
+# *notice*. Between noticing and a maintainer cutting a release, the engine
+# stays broken for everybody, and issue #28 spent six weeks in exactly that gap.
+#
+# What makes this safe is a distinction the tag scheme already draws.
+# `X.Y.Z` is what was released and validated; it is never touched here. `latest`,
+# `X.Y` and `X` already move — CI re-points them at every release — and
+# `deploy/docker-compose.yml` defaults to `latest`. So a self-hoster who wants
+# a working downloader follows a moving tag and gets a fresh yt-dlp within a
+# day; one who wants exactly what shipped pins `X.Y.Z` and is unaffected.
+#
+# The source pin is likewise never edited. `docs/operations/ytdlp-base-image.md`
+# keeps its policy — the Dockerfile is bumped by the maintainer after local
+# validation — and this workflow only passes a newer base as a `--build-arg`,
+# which is the escape hatch that document already describes for trying a
+# candidate. The weekly watcher still files its issue, so the deliberate bump
+# still happens; this just stops users waiting for it.
+
+name: Refresh yt-dlp in the published image
+
+on:
+  schedule:
+    # Daily, 05:43 UTC. Off the hour: GitHub drops scheduled runs when the
+    # whole platform stampedes at :00.
+    - cron: "43 5 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Rebuild even if the pinned base is already current"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ytdlp-refresh
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Is the released image carrying a stale yt-dlp?
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      stale: ${{ steps.check.outputs.update_available }}
+      release: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      moving_tags: ${{ steps.release.outputs.moving_tags }}
+      new_version: ${{ steps.check.outputs.new_version }}
+      new_digest: ${{ steps.check.outputs.new_digest }}
+      pinned_version: ${{ steps.check.outputs.pinned_version }}
+    steps:
+      - name: Find the current release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          version="${tag#v}"
+          owner=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          repo="ghcr.io/${owner}/content"
+          # Only the tags CI already re-points at every release. X.Y.Z is what
+          # was validated and is deliberately absent from this list.
+          case "$version" in
+            *-*) echo "A pre-release is not refreshed: $version" >&2; exit 1 ;;
+            *)
+              major="${version%%.*}"
+              minor="${version%.*}"
+              echo "moving_tags=${repo}:latest,${repo}:${minor},${repo}:${major}" >>"$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "Release $tag; moving tags will be re-pointed."
+
+      - name: Check out the released tree, not main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Compare its pin against upstream
+        id: check
+        # The same script the weekly watcher runs, against the *released*
+        # Dockerfile rather than main's — what users are running is what is
+        # being judged.
+        run: python3 .github/scripts/ytdlp_base_check.py
+        env:
+          DOCKERFILE: apps/backend/Dockerfile
+
+  refresh:
+    name: Rebuild ${{ needs.check.outputs.release }} on yt-dlp ${{ needs.check.outputs.new_version }}
+    needs: check
+    if: needs.check.outputs.stale == 'true' || inputs.force
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write # GHCR, via GITHUB_TOKEN — no stored registry secret
+    steps:
+      - name: Check out the released tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.check.outputs.release }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build for a boot check
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: content-refresh-check:local
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          provenance: false
+          sbom: false
+
+      # Nothing is published that could not start and could not download. A
+      # daily unattended publish is only defensible if it is gated on the two
+      # things that actually break: the app failing to construct (0.5.0 shipped
+      # unbootable for exactly this reason) and yt-dlp failing to run.
+      - name: The app must build and yt-dlp must answer
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python content-refresh-check:local \
+            -c 'from content.api.app import create_app; create_app(); print("app ok")'
+          got=$(docker run --rm --entrypoint yt-dlp content-refresh-check:local --version)
+          echo "yt-dlp in the rebuilt image: $got"
+          want="${{ needs.check.outputs.new_version }}"
+          # Upstream writes 2026.08.19, yt-dlp reports 2026.08.19 — but an
+          # untagged candidate leaves `want` empty, and then there is nothing
+          # to compare and nothing to publish.
+          if [ -z "$want" ]; then
+            echo "The upstream digest carries no version tag; not publishing." >&2
+            exit 1
+          fi
+          if [ "$got" != "$want" ]; then
+            echo "Expected yt-dlp $want, image reports $got." >&2
+            exit 1
+          fi
+
+      - name: Publish the moving tags
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.check.outputs.moving_tags }}
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.check.outputs.release }}
+            org.opencontainers.image.revision=${{ needs.check.outputs.release }}
+          provenance: false
+          sbom: false
+
+      # Two different things trigger a rebuild and they are worth different
+      # words, for the same reason the watcher's issue titles are: a new yt-dlp
+      # is how YouTube downloads stop working, a rebuilt base at the same
+      # version is distro patches — which is also worth having, since every
+      # CRITICAL/HIGH finding in Saturday's image scan sat in that layer.
+      - name: Say what moved
+        env:
+          WAS: ${{ needs.check.outputs.pinned_version }}
+          NOW: ${{ needs.check.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          if [ "$WAS" = "$NOW" ]; then
+            what="Base rebuilt at the same yt-dlp ($NOW) — distro patches."
+          else
+            what="New yt-dlp: $WAS → $NOW."
+          fi
+          {
+            echo "### yt-dlp refresh"
+            echo
+            echo "$what"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Release rebuilt | \`${{ needs.check.outputs.release }}\` |"
+            echo "| Tags re-pointed | \`${{ needs.check.outputs.moving_tags }}\` |"
+            echo
+            echo "\`${{ needs.check.outputs.version }}\` was **not** republished:"
+            echo "it is what was released and validated."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -90,7 +90,7 @@ RUN python3 -c "\
 import tomllib;\
 p = tomllib.load(open('pyproject.toml','rb'))['project'];\
 extras = p.get('optional-dependencies', {});\
-deps = p['dependencies'] + extras.get('pdf', []) + extras.get('read', []);\
+deps = p['dependencies'] + extras.get('pdf', []) + extras.get('read', []) + extras.get('tts', []);\
 open('/tmp/requirements.txt','w').write(chr(10).join(deps))" \
     && cat /tmp/requirements.txt \
     && pip install --no-cache-dir --only-binary=:all: --no-compile \

--- a/apps/backend/content/api/app.py
+++ b/apps/backend/content/api/app.py
@@ -65,6 +65,7 @@ from content.processors.transcript import TranscriptProcessor
 from content.providers.base import ProviderRegistry
 from content.providers.cloud_llm import CloudSummarizer
 from content.providers.documents import DocumentProvider
+from content.providers.edge_speech import EdgeSpeechRunner
 from content.providers.ffmpeg import FfmpegProvider
 from content.providers.ollama import OllamaProvider
 from content.providers.webpage import WebPageProvider
@@ -308,6 +309,11 @@ def create_app(
                     settings.typst_binary, settings.pdf_font, settings.pdf_template
                 ),
                 ReportLabPdfProcessor(settings.pdf_font),
+                # Registered whether or not the extra is installed: an absent
+                # package makes it unavailable, which the capability layer
+                # reports with a reason. A runner that is simply missing from
+                # this list reports nothing at all.
+                EdgeSpeechRunner(),
                 *summarizers,
             ],
         )

--- a/apps/backend/content/capabilities/catalog.py
+++ b/apps/backend/content/capabilities/catalog.py
@@ -113,6 +113,22 @@ OPTION_GROUPS: dict[str, tuple[OptionSpec, ...]] = {
             "Empty = take it from the rendered material.",
         ),
     ),
+    "speech": (
+        OptionSpec(
+            "voice",
+            "string",
+            "Voice",
+            "A synthesiser voice name. Empty = one that speaks `language`.",
+        ),
+        OptionSpec(
+            "language",
+            "string",
+            "Language",
+            "auto = take it from the material being read.",
+        ),
+        OptionSpec("format", "enum", "Audio format", "mp3, wav or opus."),
+        OptionSpec("speed", "float", "Speaking rate", "1.0 is the natural pace."),
+    ),
 }
 
 
@@ -345,6 +361,25 @@ CAPABILITY_CATALOG: tuple[CapabilityDef, ...] = (
         ),
     ),
     CapabilityDef(
+        "speech.generate",
+        "Read aloud",
+        "Synthesise spoken audio from readable content.",
+        "speech",
+        (
+            # Only the source-level chain, exactly as `pdf.render` declares:
+            # speaking *another output* — a summary, a translation — is a
+            # composition expressed with `from_outputs`, not a property of the
+            # source.
+            _v(
+                "speech.generate.from_text",
+                "speech.generate",
+                (T.TEXT_EXTRACT, T.TEXT_SPEAK),
+                (T.TEXT,),
+                ("speech",),
+            ),
+        ),
+    ),
+    CapabilityDef(
         "summary.generate",
         "Generate summary",
         "Summarize the content with an LLM, via a transcript.",
@@ -439,6 +474,7 @@ OUTPUT_CAPABILITY: dict[str, str] = {
     "document_text": "text.extract",
     "markdown": "markdown.export",
     "pdf": "pdf.render",
+    "speech": "speech.generate",
     # thumbnail keeps mapping to the download: it is the preferred path when the
     # source publishes an image, and the planner switches to thumbnail.generate
     # from the request's options (as it does for video.clip).

--- a/apps/backend/content/domain/request.py
+++ b/apps/backend/content/domain/request.py
@@ -51,6 +51,7 @@ EXECUTABLE_OUTPUT_TYPES = (
     "document_text",
     "markdown",
     "pdf",
+    "speech",
     "keyframes",
 )
 
@@ -512,6 +513,42 @@ class PdfOutput(BaseOutput):
     options: PdfOptions = Field(default_factory=PdfOptions)
 
 
+class SpeechOptions(StrictModel):
+    """A spoken rendering of material another output already produced.
+
+    Small for the same reason `PdfOptions` is: everything about *what* is said
+    — language of the content, length, style — belongs to the output that
+    produced the text. What is left here is how it is read aloud.
+
+    `voice` is deliberately a free string rather than an enum. The catalogue
+    belongs to whichever synthesiser is installed, it changes without this
+    contract changing, and freezing today's list into the public model would
+    make every new voice a breaking change. Empty means "the runner picks one
+    that speaks `language`", which is the answer a client usually wants.
+    """
+
+    voice: str = ""
+    # The language to read in. `auto` takes it from the material, which already
+    # carries one for a transcript, a summary or a translation.
+    language: str = "auto"
+    format: Literal["mp3", "wav", "opus"] = "mp3"
+    # 1.0 is the voice's natural pace. Bounded rather than free: past these a
+    # synthesiser stops being intelligible, and a client asking for 10x wants
+    # an error rather than 40 minutes of noise.
+    speed: float = Field(default=1.0, ge=0.5, le=2.0)
+
+    @field_validator("language")
+    @classmethod
+    def _no_original_token(cls, value: str) -> str:
+        _reject_original(value, "a speech language")
+        return value
+
+
+class SpeechOutput(BaseOutput):
+    type: Literal["speech"]
+    options: SpeechOptions = Field(default_factory=SpeechOptions)
+
+
 class ThumbnailOptions(StrictModel):
     """A thumbnail is either the one the source already publishes or one cut
     out of the video. `source` chooses; `auto` prefers the published image when
@@ -697,6 +734,7 @@ ArtifactRequest = Annotated[
         SummaryOutput,
         TranslationOutput,
         ChaptersOutput,
+        SpeechOutput,
         DocumentTextOutput,
         MarkdownOutput,
         PdfOutput,

--- a/apps/backend/content/domain/reserved.py
+++ b/apps/backend/content/domain/reserved.py
@@ -72,6 +72,26 @@ def _hints_set(request) -> bool:
 
 RESERVED_FIELDS: tuple[ReservedField, ...] = (
     ReservedField(
+        path="outputs[].options.format",
+        disposition="refuse",
+        # The voice service answers mp3. Producing wav or opus means a
+        # transcode, which is ffmpeg's job and a step of its own — so the
+        # option is declared in the contract, because the intent is real, and
+        # refused by name until that step exists. Accepting it and returning an
+        # mp3 anyway is the exact shape of promise D-01 forbids: the client
+        # gets a file, the file plays, and the format is not the one asked for.
+        triggered=lambda r: any(
+            getattr(o, "type", "") == "speech"
+            and getattr(getattr(o, "options", None), "format", "mp3") != "mp3"
+            for o in r.outputs
+        ),
+        reason=(
+            "Only `mp3` is implemented for speech: the synthesiser produces it "
+            "natively and no transcoding step is wired yet."
+        ),
+        remedy='Request `format: "mp3"`.',
+    ),
+    ReservedField(
         path="execution.mode",
         disposition="refuse",
         triggered=lambda r: r.execution.mode != "async",

--- a/apps/backend/content/domain/validation.py
+++ b/apps/backend/content/domain/validation.py
@@ -18,6 +18,14 @@ from content.domain.reserved import check_reserved
 # V1 media output types consume exactly one source and no upstream outputs.
 _SINGLE_SOURCE_TYPES = ("video", "audio", "metadata", "thumbnail", "subtitles")
 
+# The scopes under which one output instance takes one source, and where an
+# arity rule is therefore the engine's to enforce. `each_item` belongs here:
+# it fans over the members of *one* collection source (ADR 0019). Every other
+# scope is about several sources by definition, so the number of inputs is the
+# planner's business — and the planner's answer for all of them today is
+# `scope_not_supported`, which is a promise rather than a rejection.
+_ONE_INSTANCE_SCOPES = ("single", "each_item")
+
 
 class ResolvedInputs(dict):
     """output id -> (source_ids, output_ids) once resolution rules applied."""
@@ -143,6 +151,17 @@ def validate_structure(request: GenerationRequest) -> ValidationResult:
     issues.extend(resolution_issues)
 
     for index, output in enumerate(request.outputs):
+        # Both arity rules below describe **one instance consuming one input**,
+        # which is a property of the scope and not of the output type — the
+        # second one's own message has always said "with scope 'single'".
+        # Applied to every scope, they made the documented answer unreachable:
+        # a client asking for `all_sources`, the scope whose entire purpose is
+        # aggregating several sources, was told `too_many_inputs` — that its
+        # request was malformed — instead of `scope_not_supported`, that it was
+        # well-formed and simply not implemented yet. Those are different
+        # answers, and only the second one tells a client to come back later.
+        if output.scope not in _ONE_INSTANCE_SCOPES:
+            continue
         if output.type in ("transcript", "summary", "translation", "chapters"):
             # These derive from exactly one input: a source, or one upstream
             # output (transcript <- subtitles/audio; summary <- transcript;

--- a/apps/backend/content/naming/engine.py
+++ b/apps/backend/content/naming/engine.py
@@ -52,7 +52,10 @@ PRIMARY_PRECEDENCE = (
 # subtitles is subtitles — the language suffix and the extension carry the
 # rest). Semantic transformations (summary from transcript) keep their own
 # name.
-INHERIT_QUALIFIER_TYPES = frozenset({"pdf", "translation"})
+# `speech` joins them: a spoken summary is still the summary — the extension
+# is what says it is audio, and a file called "Talk - speech.mp3" tells the
+# reader nothing about which text was read.
+INHERIT_QUALIFIER_TYPES = frozenset({"pdf", "speech", "translation"})
 
 
 class OutputNaming(BaseModel):

--- a/apps/backend/content/planning/planner.py
+++ b/apps/backend/content/planning/planner.py
@@ -1494,7 +1494,7 @@ def _plan_pdf(
             outputs_by_id, builder, resolved_output_ids[0], path, errors, warnings
         )
     else:
-        dependency_id = _pdf_from_source(
+        dependency_id = _readable_from_source(
             source, source_analysis, builder, providers, path, errors, credential_id
         )
     if dependency_id is None:
@@ -1513,6 +1513,94 @@ def _plan_pdf(
             # signature. It is a server-side *name*; the public contract never
             # carries a template, a path or renderer options.
             "template": settings.pdf_template,
+        },
+        depends_on=[dependency_id],
+        resource_key=builder.step_resource_key(dependency_id),
+    )
+
+
+# --- speech ---------------------------------------------------------------------
+
+
+def _plan_speech(
+    output,
+    index: int,
+    builder: PlanBuilder,
+    outputs_by_id: dict,
+    source,
+    source_analysis: SourceAnalysis | None,
+    providers: ProviderRegistry,
+    resolved_output_ids: list[str],
+    errors: list[ValidationIssue],
+    credential_id: str | None = None,
+) -> None:
+    """Speak a sibling output, or the source's own readable text.
+
+    The same two shapes as `_plan_pdf`, because the input is the same thing:
+    readable prose. Speaking and rendering differ in what comes out, not in
+    what goes in — which is why they share `RENDERABLE_OUTPUT_TYPES` and the
+    source-side reader instead of each growing their own list.
+    """
+    path = f"outputs[{index}]"
+    options = output.options
+
+    from content.providers.base import runner_is_available
+
+    runners = [
+        runner
+        for runner in providers.runners_for_operation(T.TEXT_SPEAK)
+        if runner_is_available(runner)
+    ]
+    if not runners:
+        errors.append(
+            ValidationIssue(
+                code=codes.CAPABILITY_UNAVAILABLE,
+                path=path,
+                message=(
+                    "No speech runner is installed. Install the optional TTS "
+                    "extra to enable `speech` outputs."
+                ),
+            )
+        )
+        return
+    runner = runners[0]
+
+    if resolved_output_ids:
+        ref_id = resolved_output_ids[0]
+        ref_output = outputs_by_id.get(ref_id)
+        if ref_output is None:
+            return  # unknown reference already reported structurally
+        if ref_output.type not in RENDERABLE_OUTPUT_TYPES:
+            errors.append(
+                ValidationIssue(
+                    code=codes.INVALID_OPTION,
+                    path=f"{path}.from_outputs",
+                    message=(
+                        f"Speech reads readable content, not a "
+                        f"'{ref_output.type}' output. Expected one of: "
+                        f"{', '.join(RENDERABLE_OUTPUT_TYPES)}."
+                    ),
+                )
+            )
+            return
+        dependency_id = builder.step_of_output(ref_id)
+    else:
+        dependency_id = _readable_from_source(
+            source, source_analysis, builder, providers, path, errors, credential_id
+        )
+    if dependency_id is None:
+        return
+
+    builder.bound_step(
+        output.id,
+        operation=T.TEXT_SPEAK,
+        provider=runner.name,
+        source_id=getattr(source, "id", None),
+        params={
+            "voice": options.voice,
+            "language": options.language,
+            "format": options.format,
+            "speed": options.speed,
         },
         depends_on=[dependency_id],
         resource_key=builder.step_resource_key(dependency_id),
@@ -1667,7 +1755,7 @@ def _pdf_from_output(
     return builder.step_of_output(ref_id)  # None when that output failed
 
 
-def _pdf_from_source(
+def _readable_from_source(
     source, source_analysis, builder, providers, path, errors, credential_id
 ) -> str | None:
     """Render the source's own readable content — the article-to-PDF case."""
@@ -2346,6 +2434,23 @@ def _build_plan(
                 output_ids,
                 errors,
                 warnings,
+                credential_id,
+            )
+            continue
+
+        if output.type == "speech":
+            # Before the source guard, exactly as `pdf`: reading a sibling
+            # output aloud needs no source of its own.
+            _plan_speech(
+                output,
+                index,
+                builder,
+                outputs_by_id,
+                source,
+                source_analysis,
+                providers,
+                output_ids,
+                errors,
                 credential_id,
             )
             continue

--- a/apps/backend/content/planning/transformations.py
+++ b/apps/backend/content/planning/transformations.py
@@ -40,6 +40,12 @@ TEXT = "text"
 # *presentation* — reflowing it back into content is lossy, which is exactly why
 # rendering is its own step rather than a `format` on every text output.
 PDF = "pdf"
+# Spoken audio synthesised from readable material. Distinct from AUDIO, which
+# is a track *acquired from a source*: this one has no source track behind it,
+# it is text that was read aloud. Terminal, like PDF — nothing downstream
+# consumes it, and turning it back into text would be a transcription, not an
+# inverse.
+SPEECH = "speech"
 
 # --- operation names (stable, provider-independent verbs) ----------------------
 ACQUIRE_VIDEO = "media.acquire_video"
@@ -64,6 +70,10 @@ TEXT_EXTRACT = "text.extract"
 # to share a name. One capability, one transformation, several implementations
 # (content.pdf.typst, content.pdf.reportlab).
 RENDER_PDF = "document.render_pdf"
+# Read text aloud. Same reasoning as RENDER_PDF: `speech.generate` is the public
+# capability id, `text.speak` is the transformation, and one may have several
+# implementations (a cloud voice service, a local synthesiser).
+TEXT_SPEAK = "text.speak"
 
 
 @dataclass(frozen=True)
@@ -228,6 +238,20 @@ DEFINITIONS: tuple[TransformationDefinition, ...] = (
         operation=RENDER_PDF,
         input_kinds=(TEXT, SUMMARY, TRANSCRIPT, TRANSLATION, CHAPTERS),
         output_kinds=(PDF,),
+        lossy=True,
+    ),
+    # Read readable material aloud. It takes the same text-bearing kinds as
+    # RENDER_PDF and for the same reason: speaking is orthogonal to *what*
+    # produced the text, so it is a step rather than a `voice` option repeated
+    # on summary, transcript, translation and chapters (R1 — one declaration).
+    # `lossy`, and not deterministic: a synthesiser is free to phrase the same
+    # sentence differently between versions, so the step is not cacheable on
+    # its inputs alone.
+    TransformationDefinition(
+        operation=TEXT_SPEAK,
+        input_kinds=(TEXT, SUMMARY, TRANSCRIPT, TRANSLATION, CHAPTERS),
+        output_kinds=(SPEECH,),
+        deterministic=False,
         lossy=True,
     ),
 )

--- a/apps/backend/content/providers/edge_speech.py
+++ b/apps/backend/content/providers/edge_speech.py
@@ -1,0 +1,224 @@
+"""Read text aloud, using Microsoft Edge's voice service.
+
+`text.speak` is the transformation; this is one implementation of it. The
+boundary matters more than the implementation does: a synthesiser is exactly
+the kind of thing that gets replaced — a local one, a paid one, a better one —
+and nothing outside this file knows which is installed.
+
+**This runner is `location = "cloud"`, and that is not a detail.** It sends the
+text to a Microsoft endpoint. That classification is what makes
+`constraints.privacy.allow_cloud_providers: false` refuse it, and an engine
+whose whole selling point is self-hosting must not quietly narrate a private
+transcript to a third party. A local synthesiser would declare `local` and be
+chosen ahead of this one under the same policy; none is installed yet.
+
+The dependency is optional (`[tts]`) and probed once, like the speech-to-text
+runner: absent package, `available()` is False, and the capability resolves as
+`unavailable` with a reason instead of vanishing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.metadata
+import importlib.util
+import json
+
+from content.domain.plan import PlanStep
+from content.planning import transformations as T
+from content.providers.base import (
+    ExecutionContext,
+    Material,
+    ProducedFile,
+    StepExecutionError,
+)
+
+# What arrives from a text-bearing dependency. Same list as the PDF renderer's,
+# and for the same reason: `.json` is a transcript or chapters output asked for
+# in its canonical serialization, and it is still text.
+TEXT_SUFFIXES = (".md", ".markdown", ".txt", ".text", ".json")
+
+# A default voice per language, so `voice: ""` is a usable request rather than
+# an error. Deliberately short: these are the languages Content's own UI offers,
+# and anything else falls through to asking the service for its catalogue
+# rather than guessing wrong. Neural voices, because the older ones are the
+# reason people think synthesis sounds like 2005.
+# Verified against `edge_tts.list_voices()` on 2026-08-25 rather than written
+# from memory — the first draft of this map invented `fr-FR-DenisePotentialNeural`,
+# which sounds exactly like a real voice name and is not one.
+DEFAULT_VOICES = {
+    "fr": "fr-FR-DeniseNeural",
+    "en": "en-US-AriaNeural",
+    "es": "es-ES-ElviraNeural",
+    "de": "de-DE-KatjaNeural",
+    "it": "it-IT-ElsaNeural",
+    "pt": "pt-BR-FranciscaNeural",
+    "nl": "nl-NL-ColetteNeural",
+}
+FALLBACK_VOICE = "en-US-AriaNeural"
+
+# The service answers mp3. Anything else would be a transcode, which is
+# ffmpeg's job and a step of its own; `reserved.py` refuses the other formats
+# by name rather than letting a client discover the silence.
+NATIVE_FORMAT = "mp3"
+
+# Long text is split by the library itself, but a synthesiser reading an
+# eight-hour transcript is almost never what was meant, and the run costs real
+# minutes before anyone finds out. Warn — the same channel the truncated-summary
+# warning uses — and carry on: refusing would be worse for the person who did
+# mean it.
+_LONG_TEXT_CHARS = 200_000
+
+
+def text_from_material(material: Material) -> str:
+    """The words to read, out of whatever the dependency produced.
+
+    A canonical transcript is JSON with timed segments; spoken aloud, the
+    timings are noise, so the segment texts are joined and nothing else.
+    """
+    content = material.path.read_text(errors="replace")
+    if material.path.suffix.lower() == ".json":
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError:
+            return content.strip()
+        segments = payload.get("segments") if isinstance(payload, dict) else None
+        if isinstance(segments, list):
+            return "\n".join(
+                str(segment.get("text", ""))
+                for segment in segments
+                if isinstance(segment, dict)
+            ).strip()
+        return content.strip()
+    return content.strip()
+
+
+def rate_for(speed: float) -> str:
+    """`1.15` -> `"+15%"`, which is the only shape the library accepts.
+
+    Rounded to whole percent: the service ignores finer granularity, and a
+    string like `+14.999%` is rejected outright.
+    """
+    percent = round((float(speed) - 1.0) * 100)
+    return f"{percent:+d}%"
+
+
+def voice_for(language: str, requested: str) -> str:
+    """An explicit voice wins; otherwise the language decides."""
+    if requested:
+        return requested
+    base = (language or "").strip().lower().replace("_", "-").split("-")[0]
+    return DEFAULT_VOICES.get(base, FALLBACK_VOICE)
+
+
+class EdgeSpeechRunner:
+    name = "edge_tts"
+    # See the module docstring. This value is the privacy guarantee.
+    location = "cloud"
+    operations = (T.TEXT_SPEAK,)
+
+    def __init__(self) -> None:
+        self.tool_version = ""
+        self._available: bool | None = None
+
+    # --- availability (installation capability) --------------------------------
+
+    def available(self) -> bool:
+        """The optional TTS extra is installed. Probed once — a Python library
+        does not appear or vanish mid-process."""
+        if self._available is None:
+            self._available = importlib.util.find_spec("edge_tts") is not None
+            if self._available:
+                try:
+                    version = importlib.metadata.version("edge-tts")
+                except importlib.metadata.PackageNotFoundError:
+                    version = "?"
+                self.tool_version = f"edge-tts/{version}"
+        return self._available
+
+    # --- execution --------------------------------------------------------------
+
+    def execute(self, step: PlanStep, ctx: ExecutionContext) -> list[ProducedFile]:
+        if step.operation != T.TEXT_SPEAK:
+            raise StepExecutionError(
+                "operation_not_supported",
+                f"Runner '{self.name}' cannot execute '{step.operation}'.",
+            )
+        if not self.available():
+            raise StepExecutionError(
+                "provider_error",
+                "The text-to-speech extra is not installed "
+                "(pip install 'content-backend[tts]').",
+            )
+
+        material = self._pick_material(ctx.input_materials)
+        if material is None:
+            raise StepExecutionError(
+                "no_input", "No text material was produced by the dependency step."
+            )
+        text = text_from_material(material)
+        if not text:
+            # An empty artifact that plays silence is the failure mode nobody
+            # notices until they listen to it.
+            raise StepExecutionError("no_input", "The material to read aloud is empty.")
+        if len(text) > _LONG_TEXT_CHARS:
+            ctx.on_warning(
+                "long_synthesis",
+                f"Reading {len(text)} characters aloud: this will take a while "
+                "and produce a very long file.",
+                {"provider": self.name, "characters": len(text)},
+            )
+
+        language = str(step.params.get("language") or "auto")
+        voice = voice_for(language, str(step.params.get("voice") or ""))
+        rate = rate_for(step.params.get("speed", 1.0))
+        target = ctx.workdir / f"{step.id}.{NATIVE_FORMAT}"
+
+        ctx.on_progress(5.0, f"Synthesising with {voice}")
+        self._synthesise(text, voice, rate, target)
+        if not target.exists() or target.stat().st_size == 0:
+            raise StepExecutionError(
+                "provider_error",
+                f"The voice service returned nothing for voice '{voice}'.",
+            )
+        ctx.on_progress(100.0, "Spoken")
+
+        return [
+            ProducedFile(
+                path=target,
+                media_type="audio/mpeg",
+                attributes={
+                    "voice": voice,
+                    "rate": rate,
+                    "language": language,
+                    "derived_from": material.path.suffix.lstrip(".") or "text",
+                    "characters": str(len(text)),
+                },
+            )
+        ]
+
+    # --- the one call that leaves the machine -----------------------------------
+
+    def _synthesise(self, text: str, voice: str, rate: str, target) -> None:
+        import edge_tts
+
+        async def run() -> None:
+            await edge_tts.Communicate(text, voice, rate=rate).save(str(target))
+
+        try:
+            # A step runs in a worker thread, which has no event loop of its
+            # own, so this owns one for the duration of the call.
+            asyncio.run(run())
+        except Exception as exc:  # noqa: BLE001 — the library raises broadly
+            raise StepExecutionError(
+                "provider_error",
+                f"Speech synthesis failed ({type(exc).__name__}): {exc}",
+            ) from exc
+
+    def _pick_material(self, materials: list[Material]) -> Material | None:
+        for material in materials:
+            if material.path.suffix.lower() in TEXT_SUFFIXES:
+                return material
+        # The planner only binds this step behind a text-bearing one, so an
+        # unexpected suffix is likelier a new text format than a mismatch.
+        return materials[0] if materials else None

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -32,6 +32,12 @@ dev = [
 stt = [
     "faster-whisper>=1.0",
 ]
+# Optional text-to-speech runner (text.speak): installing it activates the
+# `speech` output. Pure Python and tiny, unlike the STT wheels — but it is a
+# *cloud* runner, so it stays behind an extra rather than being assumed.
+tts = [
+    "edge-tts>=7.0",
+]
 # Optional document *reader* (a `.pdf` file source): installing it lets the
 # document provider extract a PDF's text layer. pypdf is BSD-3-Clause and a
 # pure-Python wheel — the same two properties that decided reportlab below, so

--- a/apps/backend/tests/test_capability_contract.py
+++ b/apps/backend/tests/test_capability_contract.py
@@ -45,6 +45,9 @@ STABLE_CAPABILITY_IDS = {
     "markdown.export",
     # Rendering readable content into a paginated document.
     "pdf.render",
+    # Reading readable content aloud. Same input as pdf.render: what differs is
+    # what comes out, not what goes in.
+    "speech.generate",
     # Frames cut out of the video itself (prompt 11).
     "thumbnail.generate",
     "keyframes.extract",

--- a/apps/backend/tests/test_contract_validation.py
+++ b/apps/backend/tests/test_contract_validation.py
@@ -271,3 +271,56 @@ def test_no_public_field_is_accepted_without_being_classified():
         f"reserved: {sorted(unclassified)} — read them in the engine, or add "
         "them to content/domain/reserved.py with a refusal or a warning"
     )
+
+
+# --- multi-source scopes answer "not yet", not "malformed" ----------------------
+
+
+def _two_source_payload(**output):
+    return {
+        "schema_version": "1.0",
+        "sources": [
+            {"id": "a", "type": "text", "content": "one"},
+            {"id": "b", "type": "text", "content": "two"},
+        ],
+        "outputs": [{"id": "s", "from_sources": ["a", "b"], **output}],
+    }
+
+
+@pytest.mark.parametrize("scope", ["all_sources", "each_source", "group"])
+def test_a_multi_source_scope_is_well_formed(scope):
+    """Content is meant to aggregate several sources; `all_sources` is the
+    scope that says so, and Studio already offers up to eight sources.
+
+    Structural validation used to answer `too_many_inputs` here — *your request
+    is malformed* — because an arity rule written for one instance consuming
+    one source was applied to every scope. That made the documented answer
+    unreachable: the contract promises `scope_not_supported`, "valid but not
+    supported by the current execution engine", and a client cannot tell from
+    `too_many_inputs` that the thing it asked for is coming.
+    """
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope=scope))
+    )
+    assert "too_many_inputs" not in codes_of(result)
+    assert result.valid, codes_of(result)
+
+
+@pytest.mark.parametrize("output_type", ["summary", "transcript", "video", "audio"])
+def test_single_scope_still_takes_exactly_one_source(output_type):
+    """The rule is not gone, it is scoped. One instance still consumes one
+    source, which is what `single` means."""
+    result = validate_structure(
+        make_request(_two_source_payload(type=output_type, scope="single"))
+    )
+    assert "too_many_inputs" in codes_of(result)
+
+
+def test_each_item_still_takes_exactly_one_source():
+    """`each_item` fans over the members of *one* collection (ADR 0019), so it
+    keeps the arity rule — and must not become a silent no-op in the planner,
+    which returns early when the count is not one."""
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope="each_item"))
+    )
+    assert "too_many_inputs" in codes_of(result)

--- a/apps/backend/tests/test_speech.py
+++ b/apps/backend/tests/test_speech.py
@@ -1,0 +1,266 @@
+"""Reading text aloud: the contract, the planning, and the one call that leaves.
+
+`speech` is a new output type whose input is the same thing a PDF's is —
+readable prose — so most of what is tested here is that it behaves like its
+sibling rather than like a new special case.
+
+Nothing in this file touches the network. The synthesiser is a boundary, and
+the point of a boundary is that everything around it can be tested without it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from content.domain.request import GenerationRequest
+from content.domain.validation import validate_structure
+from content.providers.base import Material
+from content.providers.edge_speech import (
+    DEFAULT_VOICES,
+    FALLBACK_VOICE,
+    EdgeSpeechRunner,
+    rate_for,
+    text_from_material,
+    voice_for,
+)
+
+
+def _request(**output) -> GenerationRequest:
+    return GenerationRequest.model_validate(
+        {
+            "schema_version": "1.0",
+            "sources": [{"id": "a", "type": "url", "uri": "https://example.com/talk"}],
+            "outputs": [{"id": "sp", "type": "speech", **output}],
+        }
+    )
+
+
+# --- the public contract ---------------------------------------------------------
+
+
+def test_speech_is_a_first_class_output_type():
+    request = _request()
+    assert validate_structure(request).valid
+    assert request.outputs[0].options.format == "mp3"
+    assert request.outputs[0].options.speed == 1.0
+
+
+def test_an_unusable_speaking_rate_is_refused_by_the_schema():
+    """Past these bounds a synthesiser stops being intelligible. A client
+    asking for 10x wants an error, not forty minutes of noise."""
+    with pytest.raises(Exception):
+        _request(options={"speed": 10})
+
+
+@pytest.mark.parametrize("fmt", ["wav", "opus"])
+def test_an_unimplemented_format_is_refused_by_name(fmt):
+    """The service answers mp3; anything else is a transcode nobody has wired.
+
+    Declared in the contract because the intent is real, refused because
+    returning an mp3 labelled `wav` is the promise D-01 forbids — the client
+    gets a file, the file plays, and it is not what was asked for.
+    """
+    result = validate_structure(_request(options={"format": fmt}))
+    assert not result.valid
+    assert [e.code for e in result.errors] == ["option_not_supported"]
+    assert "mp3" in result.errors[0].message
+
+
+# --- choosing a voice and a rate --------------------------------------------------
+
+
+def test_the_language_picks_a_voice_when_none_is_named():
+    assert voice_for("fr", "") == DEFAULT_VOICES["fr"]
+    assert voice_for("fr-FR", "") == DEFAULT_VOICES["fr"]
+    assert voice_for("FR_fr", "") == DEFAULT_VOICES["fr"]
+
+
+def test_an_explicit_voice_always_wins():
+    assert voice_for("fr", "en-GB-SoniaNeural") == "en-GB-SoniaNeural"
+
+
+def test_an_unknown_language_falls_back_rather_than_guessing():
+    """Inventing `xx-XX-SomethingNeural` would fail at the service with a
+    message nobody can act on. The first draft of the default map invented a
+    French voice that does not exist, which is exactly how this goes wrong."""
+    assert voice_for("kl", "") == FALLBACK_VOICE
+    assert voice_for("", "") == FALLBACK_VOICE
+
+
+def test_every_default_voice_is_shaped_like_a_real_one():
+    """Cannot check existence offline; can check nobody typed a bare name.
+    Verified against `edge_tts.list_voices()` when the map was written."""
+    for language, voice in {**DEFAULT_VOICES, "_": FALLBACK_VOICE}.items():
+        assert voice.endswith("Neural"), voice
+        assert voice.count("-") >= 2, voice
+
+
+@pytest.mark.parametrize(
+    ("speed", "expected"),
+    [(1.0, "+0%"), (1.15, "+15%"), (0.5, "-50%"), (2.0, "+100%"), (1.001, "+0%")],
+)
+def test_the_rate_is_whole_percent(speed, expected):
+    """`+14.999%` is rejected outright by the library, so the conversion
+    rounds rather than formats."""
+    assert rate_for(speed) == expected
+
+
+# --- reading the material ---------------------------------------------------------
+
+
+def test_a_canonical_transcript_is_read_without_its_timings(tmp_path):
+    """Spoken aloud, the timings are noise."""
+    path = tmp_path / "t.json"
+    path.write_text(
+        json.dumps(
+            {
+                "segments": [
+                    {"start": 0.0, "end": 1.0, "text": "Bonjour."},
+                    {"start": 1.0, "end": 2.0, "text": "Ça va ?"},
+                ]
+            }
+        )
+    )
+    assert text_from_material(Material(path=path, media_type="application/json")) == (
+        "Bonjour.\nÇa va ?"
+    )
+
+
+def test_malformed_json_is_read_as_the_text_it_is(tmp_path):
+    path = tmp_path / "t.json"
+    path.write_text("not json at all")
+    assert (
+        text_from_material(Material(path=path, media_type="application/json"))
+        == "not json at all"
+    )
+
+
+def test_markdown_is_read_verbatim(tmp_path):
+    path = tmp_path / "s.md"
+    path.write_text("# Titre\n\nUn paragraphe.\n")
+    assert text_from_material(Material(path=path, media_type="text/markdown")) == (
+        "# Titre\n\nUn paragraphe."
+    )
+
+
+# --- the runner, without the network ----------------------------------------------
+
+
+class _Ctx:
+    def __init__(self, workdir, materials):
+        self.workdir = workdir
+        self.input_materials = materials
+        self.warnings = []
+        self.timeout_seconds = 60.0
+
+    def on_progress(self, percent, message):
+        pass
+
+    def on_warning(self, code, message, details):
+        self.warnings.append((code, message, details))
+
+
+def _step(**params):
+    from content.domain.plan import PlanStep
+
+    return PlanStep(
+        id="speak_sp",
+        operation="text.speak",
+        provider="edge_tts",
+        params=params,
+        depends_on=[],
+    )
+
+
+def test_empty_material_fails_instead_of_producing_silence(tmp_path):
+    """An artifact that plays nothing is the failure nobody notices until they
+    listen to it."""
+    from content.providers.base import StepExecutionError
+
+    path = tmp_path / "s.md"
+    path.write_text("   \n\n ")
+    runner = EdgeSpeechRunner()
+    if not runner.available():
+        pytest.skip("the tts extra is not installed here")
+    with pytest.raises(StepExecutionError) as raised:
+        runner.execute(
+            _step(), _Ctx(tmp_path, [Material(path=path, media_type="text/markdown")])
+        )
+    assert raised.value.code == "no_input"
+
+
+def test_a_very_long_text_warns_before_spending_the_minutes(tmp_path, monkeypatch):
+    """Same channel as the truncated-summary warning: the step still runs, and
+    it says out loud what it is about to cost."""
+
+    path = tmp_path / "s.md"
+    path.write_text("a " * 120_000)
+    runner = EdgeSpeechRunner()
+    monkeypatch.setattr(runner, "available", lambda: True)
+    monkeypatch.setattr(
+        runner,
+        "_synthesise",
+        lambda text, voice, rate, target: target.write_bytes(b"x"),
+    )
+    ctx = _Ctx(tmp_path, [Material(path=path, media_type="text/markdown")])
+
+    produced = runner.execute(_step(voice="fr-FR-DeniseNeural"), ctx)
+
+    assert [w[0] for w in ctx.warnings] == ["long_synthesis"]
+    assert produced[0].media_type == "audio/mpeg"
+
+
+def test_what_was_said_and_how_travels_with_the_artifact(tmp_path, monkeypatch):
+    """`voice` is the one thing that cannot be recovered from the file, and it
+    is the first thing asked when a recording sounds wrong."""
+    path = tmp_path / "s.md"
+    path.write_text("Bonjour tout le monde.")
+    runner = EdgeSpeechRunner()
+    monkeypatch.setattr(runner, "available", lambda: True)
+    monkeypatch.setattr(
+        runner,
+        "_synthesise",
+        lambda text, voice, rate, target: target.write_bytes(b"x"),
+    )
+
+    produced = runner.execute(
+        _step(language="fr", speed=1.2),
+        _Ctx(tmp_path, [Material(path=path, media_type="text/markdown")]),
+    )
+
+    attributes = produced[0].attributes
+    assert attributes["voice"] == DEFAULT_VOICES["fr"]
+    assert attributes["rate"] == "+20%"
+    assert attributes["language"] == "fr"
+
+
+def test_a_runner_asked_for_the_wrong_operation_refuses(tmp_path):
+    from content.providers.base import StepExecutionError
+
+    runner = EdgeSpeechRunner()
+    step = _step()
+    step.operation = "text.summarize"
+    with pytest.raises(StepExecutionError) as raised:
+        runner.execute(step, _Ctx(tmp_path, []))
+    assert raised.value.code == "operation_not_supported"
+
+
+# --- the privacy classification, which is the whole guarantee ---------------------
+
+
+def test_the_runner_declares_itself_cloud():
+    """This value is what makes `allow_cloud_providers: false` refuse it. An
+    engine whose selling point is self-hosting must not quietly narrate a
+    private transcript to a third party, and the only thing standing between
+    those two facts is this attribute."""
+    assert EdgeSpeechRunner().location == "cloud"
+
+
+def test_a_private_policy_rejects_it():
+    from content.capabilities.policy import EffectivePolicy
+
+    runner = EdgeSpeechRunner()
+    assert not EffectivePolicy(allow_cloud_providers=False).allows_runner(runner)
+    assert EffectivePolicy(allow_cloud_providers=True).allows_runner(runner)

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -93,6 +93,27 @@ def _actionable(exc: ContentError, base_url: str) -> str:
     return str(exc)
 
 
+# The SDK draws a line Content already believed in: a failure you *anticipated*
+# is reported with your message, and anything else is a crash whose text is
+# withheld from the model. `ToolError` is how a handler says which one this is.
+#
+# Raising a bare `RuntimeError` put every engine failure on the wrong side of
+# that line: from mcp 2.1 an agent asking about an unreachable engine was told
+# "Error executing tool get_config" and nothing more — no URL, no remedy, which
+# is exactly the answer `_actionable` exists to prevent.
+#
+# Imported defensively because the floor is `mcp>=1.2`: the class moved with
+# the fastmcp-to-mcpserver rename, and on a release that has neither, a plain
+# exception is the old behaviour rather than a crash at import time.
+try:  # mcp >= 2.1
+    from mcp.server.mcpserver.exceptions import ToolError
+except ImportError:  # pragma: no cover - depends on the installed mcp
+    try:  # mcp < 2.1
+        from mcp.server.fastmcp.exceptions import ToolError
+    except ImportError:
+        ToolError = RuntimeError  # type: ignore[assignment, misc]
+
+
 def _friendly(fn, client: ContentClient):
     """Wrap one tool so SDK errors surface as guidance rather than errno."""
 
@@ -101,7 +122,17 @@ def _friendly(fn, client: ContentClient):
         try:
             return fn(*args, **kwargs)
         except ContentError as exc:
-            raise RuntimeError(_actionable(exc, client.base_url)) from exc
+            # Anticipated: the engine answered, and what it answered is the
+            # most useful thing the agent can be told.
+            raise ToolError(_actionable(exc, client.base_url)) from exc
+        except (ValueError, TypeError) as exc:
+            # The service's own rejections of a malformed call — "this output
+            # has no 'type'", with the example that fixes it. Anticipated in
+            # the strongest sense: the message exists precisely so the agent
+            # can correct itself without a round trip to the engine. Translated
+            # here rather than raised as ToolError inside `service`, which has
+            # no business importing the MCP SDK.
+            raise ToolError(str(exc)) from exc
 
     return wrapper
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -163,7 +163,7 @@ and this paragraph is the reservation: a future language code spelled
 1. `from_sources` and `from_outputs` list existing ids; otherwise `unknown_source_reference` / `unknown_output_reference`.
 2. The `from_outputs` graph must be acyclic (`dependency_cycle`).
 3. If both are empty: the output consumes **the single source** of the request if `sources` holds only one; otherwise the `role: primary` source if it is unique; otherwise the error `ambiguous_inputs` ("precise from_sources"). No other inference.
-4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise).
+4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise). **This arity is a property of the scope, not of the type**: it binds `single` and `each_item`, both of which resolve one instance to one source. A scope that is *about* several sources — `each_source`, `all_sources`, `group` — is never `too_many_inputs`; it is well-formed, and today it answers `scope_not_supported`.
 5. A dependency that is declared but technically useless is not an error: it constrains ordering (the step waits) and the provenance. The planner never silently "corrects" the client's declarations.
 
 ### `scope`

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -117,6 +117,7 @@ A union discriminated by `type` (a logical result, never a tool):
 | `document_text` | `format` (`text` flattens the reading\|`markdown` keeps its structure). Input: a readable source (a web page, a `.txt`/`.md` file, an inline `text` source) | 1 |
 | `markdown` | *(none yet)* — Markdown is the extractor's canonical form. Input: a readable source | 1 |
 | `pdf` | `page_size` (`a4`\|`letter`), `title` (empty = taken from the rendered material). Input: a readable source **or**, through `from_outputs`, any readable output (`summary`, `transcript`, `translation`, `chapters`, `markdown`, `document_text`). Rendered by an operator-selected implementation (Typst or ReportLab) — the renderer, its template and its fonts are **operator configuration, never contract**; the chosen backend appears in the artifact's provenance. See [operations/pdf-rendering.md](operations/pdf-rendering.md) | 1 |
+| `speech` | `voice` (empty = one that speaks `language`), `language` (`auto` = from the material), `format` (`mp3`; `wav`/`opus` are declared and refused with `option_not_supported` until a transcoding step exists), `speed` (0.5–2.0, 1.0 = natural). Input: the same readable source **or** readable output as `pdf` — speaking and rendering differ in what comes out, not in what goes in. Synthesised by an installed runner; the shipped one (`edge_tts`) is **`location: cloud`**, so the text leaves the machine and `constraints.privacy.allow_cloud_providers: false` refuses it. The voice and rate appear in the artifact's provenance | 1 |
 
 ### Types declared but not executed in V1
 

--- a/docs/operations/ytdlp-base-image.md
+++ b/docs/operations/ytdlp-base-image.md
@@ -15,12 +15,39 @@ hard, notice automatically, upgrade deliberately.**
 | --- | --- |
 | **Pinned** | An explicit version *and* an immutable digest — never `:latest` |
 | **Detected** | A scheduled workflow compares the pin against upstream every week |
-| **Upgraded** | Only by the maintainer, only after local validation passes |
-| **Never** | No automatic bump, no dependency-update pull request, no auto-merge, no auto-publish |
+| **Upgraded** | The pin in the Dockerfile: only by the maintainer, only after local validation passes |
+| **Refreshed** | The *moving image tags*: daily and unattended, gated on a boot check and a `yt-dlp --version` check |
+| **Never** | No automatic edit to the pin, no auto-merge, and never a republished `X.Y.Z` |
 
-Pull requests are disabled on this repository ([CONTRIBUTING.md](../../CONTRIBUTING.md)),
-so the usual bot-opens-a-PR mechanism is not available and would not be wanted.
-The workflow files **an issue** instead: a notification, not a change.
+The workflow files **an issue** rather than opening a pull request: a
+notification, not a change. Unsolicited pull requests are closed unread
+([CONTRIBUTING.md](../../CONTRIBUTING.md)) — the maintainer's own are the normal
+route for everything else, and Dependabot opens them for pinned actions, but a
+base-image bump wants the local validation below rather than a green tick.
+
+### Why the tags are refreshed and the pin is not
+
+A watcher only shortens the time to *notice*. Between noticing and a release,
+every user's downloader stays broken — issue #28 spent six weeks in that gap,
+and the failure mode is total: "No video formats found", not a degraded result.
+
+What makes an unattended rebuild safe here is a distinction the tag scheme
+already draws. `X.Y.Z` is what was released and validated, and nothing
+republishes it. `latest`, `X.Y` and `X` **already move** — CI re-points them at
+every release, and `deploy/docker-compose.yml` defaults to `latest`. So
+`.github/workflows/ytdlp-refresh.yml` rebuilds the released tree on the newest
+base and re-points only those, which is a promise none of them were making.
+
+The source pin is untouched: the refresh passes the newer base as a
+`--build-arg`, the escape hatch described below. The weekly issue still gets
+filed, and the deliberate bump still happens — this only stops users waiting
+for it.
+
+It also catches something the yt-dlp framing misses. Upstream republishes the
+same yt-dlp version when the distro underneath it is patched, and every
+CRITICAL/HIGH finding in the image scan (ADR 0026) lives in exactly that layer.
+So the trigger is a **digest** change, not a version change, and the run summary
+says which of the two happened.
 
 ## How the pin is written
 

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -55,11 +55,13 @@ SOURCES = (
     ("Files", "one or many, uploaded"),
     ("Texts", "pasted or batched"),
 )
-# Plural, because `sources` is an array and a single job really does carry
-# several — verified: three sources each with their own outputs validates. The
-# caption is there to stop the plural over-claiming: an output consuming two
-# sources at once is refused (`too_many_inputs`), so the promise is "many
-# sources in one job", not "many sources merged into one file".
+# Plural, because `sources` is documented 1..N and a job really does carry
+# several — Studio offers up to eight. The caption bounds the claim to what
+# runs today: several sources, each producing its own artifacts, in one job.
+# Aggregating several sources into one artifact is the `all_sources` scope,
+# which is designed, documented as "one aggregated result (fan-in)", and not
+# yet implemented — so the engine answers `scope_not_supported` rather than
+# refusing the request.
 SOURCES_NOTE = "several in a single job"
 STEPS = (
     ("Analyze", "understand"),

--- a/tests/test_ytdlp_base_check.py
+++ b/tests/test_ytdlp_base_check.py
@@ -49,3 +49,75 @@ def test_the_body_opens_on_the_distinction_too():
     # Both keep the promise the workflow makes: it never edits anything.
     for body in (upgrade, rebuild):
         assert "Nothing has been changed" in body
+
+
+# --- what the refresh workflow builds with -------------------------------------
+
+
+def test_the_check_exposes_what_a_rebuild_needs(tmp_path, monkeypatch):
+    """The daily refresh rebuilds the released tree on the newer base, so it
+    needs the version and the digest the check resolved — not just a boolean.
+
+    The digest is what Docker resolves and is the authority; the version rides
+    along so the rebuilt image can still say, in a label a human reads, which
+    yt-dlp is inside it.
+    """
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.01.01\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    assert written["pinned_version"] == "2026.01.01"
+    assert written["new_version"] == "2026.08.19"
+    assert written["new_digest"] == "sha256:" + "b" * 64
+
+
+def test_a_rebuilt_base_still_reports_its_version(tmp_path, monkeypatch):
+    """Upstream republishes the same yt-dlp when the distro under it is
+    patched. That is a digest change with no version change, it is still worth
+    rebuilding for — the image scan's findings all live in that layer — and the
+    two must stay distinguishable downstream."""
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.08.19\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    # Same version on both sides: the refresh must still be able to tell the
+    # reader this was a rebuild rather than a new yt-dlp.
+    assert written["pinned_version"] == written["new_version"] == "2026.08.19"


### PR DESCRIPTION
Prompt 07. A new output type, `speech`: ask for it and the job returns an mp3 of the text being spoken — the source's own readable content, or any readable output the job already produced, through `from_outputs`.

## Proven on a running engine, not only in tests

```
Le principe de Content - speech - fr.mp3   audio/mpeg   121 536 bytes
provenance: voice=fr-FR-DeniseNeural  rate=+5%  language=fr  tool=edge-tts/7.2.8
```

24 kHz mono, real French. The chained case works too — a `markdown` output spoken through `from_outputs` returns both artifacts in one job — and `speech.generate` resolves as **derivable** on a text source.

## It follows `pdf`, deliberately

The input is the same thing: readable prose. Speaking and rendering differ in what comes *out*, not what goes *in*, so they share `RENDERABLE_OUTPUT_TYPES` and the source-side text reader rather than each growing a private list. `text.speak` is the transformation, `speech.generate` the public capability — same split as `document.render_pdf` / `pdf.render`. Naming treats it the same way too: a spoken summary is still the summary, so it inherits its upstream qualifier.

## The load-bearing line

```python
location = "cloud"
```

edge-tts sends the text to a Microsoft endpoint. An engine whose selling point is self-hosting must not quietly narrate a private transcript to a third party — so that attribute is what makes `allow_cloud_providers: false` refuse it, and a local synthesiser would declare `local` and win under the same policy. **There is a test on it**, because it's a guarantee rather than a label.

## Two places the easy thing would have been a lie

- **`format`** accepts `wav`/`opus` in the contract because the intent is real, but the service answers mp3 and no transcoding step is wired. Returning an mp3 labelled `wav` is exactly the promise D-01 forbids, so they're refused by name with the remedy. When ffmpeg gets a transcode step, the refusal is what gets deleted.
- **Empty material fails** rather than producing a file that plays silence — the failure nobody notices until they listen to it.

## One bug I caught in myself

The default voice map is verified against `edge_tts.list_voices()` rather than written from memory. My first draft invented **`fr-FR-DenisePotentialNeural`**, which sounds exactly like a real voice name and is not one. An unknown language now falls back instead of guessing a plausible string that fails at the service with a message nobody can act on.

## Notes

- `edge-tts` is an optional extra (`[tts]`), but installed in the image by default — it's pure Python and tiny, unlike the STT wheels.
- 22 new tests, **none touching the network**. The synthesiser is a boundary; the point of a boundary is that everything around it is testable without it.
- Two existing guards caught me adding a public capability without declaring it (`OPTION_GROUPS`, `STABLE_CAPABILITY_IDS`). They work.

806 backend tests green.