### PR TITLE
Say ToolError, so the agent still hears why

### DIFF
--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -93,6 +93,27 @@ def _actionable(exc: ContentError, base_url: str) -> str:
     return str(exc)
 
 
+# The SDK draws a line Content already believed in: a failure you *anticipated*
+# is reported with your message, and anything else is a crash whose text is
+# withheld from the model. `ToolError` is how a handler says which one this is.
+#
+# Raising a bare `RuntimeError` put every engine failure on the wrong side of
+# that line: from mcp 2.1 an agent asking about an unreachable engine was told
+# "Error executing tool get_config" and nothing more — no URL, no remedy, which
+# is exactly the answer `_actionable` exists to prevent.
+#
+# Imported defensively because the floor is `mcp>=1.2`: the class moved with
+# the fastmcp-to-mcpserver rename, and on a release that has neither, a plain
+# exception is the old behaviour rather than a crash at import time.
+try:  # mcp >= 2.1
+    from mcp.server.mcpserver.exceptions import ToolError
+except ImportError:  # pragma: no cover - depends on the installed mcp
+    try:  # mcp < 2.1
+        from mcp.server.fastmcp.exceptions import ToolError
+    except ImportError:
+        ToolError = RuntimeError  # type: ignore[assignment, misc]
+
+
 def _friendly(fn, client: ContentClient):
     """Wrap one tool so SDK errors surface as guidance rather than errno."""
 
@@ -101,7 +122,17 @@ def _friendly(fn, client: ContentClient):
         try:
             return fn(*args, **kwargs)
         except ContentError as exc:
-            raise RuntimeError(_actionable(exc, client.base_url)) from exc
+            # Anticipated: the engine answered, and what it answered is the
+            # most useful thing the agent can be told.
+            raise ToolError(_actionable(exc, client.base_url)) from exc
+        except (ValueError, TypeError) as exc:
+            # The service's own rejections of a malformed call — "this output
+            # has no 'type'", with the example that fixes it. Anticipated in
+            # the strongest sense: the message exists precisely so the agent
+            # can correct itself without a round trip to the engine. Translated
+            # here rather than raised as ToolError inside `service`, which has
+            # no business importing the MCP SDK.
+            raise ToolError(str(exc)) from exc
 
     return wrapper
 


### PR DESCRIPTION
**Urgent — `main` will go red on its next run.** Every branch went red tonight without a line of MCP code changing.

## What happened

`mcp 2.1.0` was published at **19:04 UTC today**. The dependency is `mcp>=1.2` — a floor, no ceiling — and there is no lockfile, so the next CI run resolved it and the ground moved. `main` was green at 14:23, before the release. This is **ADR 0026's first finding arriving in person.**

## The change is a good one, and we were on the wrong side of it

2.1.0 distinguishes a failure you *anticipated* from a crash:

> **`ToolError`** — "the call returns `is_error=True` with **your message** in `content` for the model to read"
> Anything else — "the model sees only `Error executing tool <name>`"

Every engine failure here raised a bare `RuntimeError`. So an agent asking about an unreachable engine got:

```
Error executing tool get_config
```

No URL, no remedy — precisely the answer `_actionable` exists to prevent. Same for an expired analysis and for a refused request's stable codes. The tests caught it because they assert on the *text*, not merely on failing.

## The fix

Both kinds of anticipated failure now say so:

- engine errors keep going through `_actionable`
- the service's own rejections of a malformed call — *"this output has no `'type'`"*, with the example that fixes it — are translated at the same boundary, rather than inside `service`, which has no business importing an MCP SDK

The import is defensive because the floor is `mcp>=1.2` and the class moved with the fastmcp→mcpserver rename. **Verified green against 2.1.0 and against 2.0.0.**

## What this does not fix

The dependency question. A floor with no ceiling and no lockfile means any release, anywhere, can turn every branch red between two runs of identical code — which is exactly what happened. Worth deciding on separately; it's finding 1 of ADR 0026 and it now has a real incident behind it.