### PR TITLE
Session: MCP unblocked, yt-dlp kept fresh, and several sources answered honestly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ CONTENT_ALLOW_PRIVATE_NETWORKS=false
 # Ollama daemon as seen from the container; empty model = first installed.
 CONTENT_OLLAMA_URL=http://host.docker.internal:11434
 CONTENT_OLLAMA_MODEL=
+# Context window ceiling asked of Ollama. 32768 covers roughly 2 h 20 of
+# speech in one summary; past its window Ollama keeps half of it, so a
+# slightly-too-long transcript loses more than half. Raise it (and give
+# Ollama the RAM) for longer recordings; 0 = let the daemon decide.
+CONTENT_OLLAMA_MAX_CONTEXT=32768
 # Cloud summarizers (secrets — leave empty to disable).
 CONTENT_ANTHROPIC_API_KEY=
 CONTENT_OPENAI_API_KEY=

--- a/.github/scripts/ytdlp_base_check.py
+++ b/.github/scripts/ytdlp_base_check.py
@@ -225,6 +225,13 @@ def main() -> None:
         with open(output, "a", encoding="utf-8") as handle:
             handle.write(f"update_available={str(not up_to_date).lower()}\n")
             handle.write(f"issue_title={title}\n")
+            # What the refresh workflow builds with. The digest is the
+            # authority — it is what Docker resolves and it is immutable — and
+            # the version is carried alongside so the rebuilt image can still
+            # say, in a label a human reads, which yt-dlp is inside it.
+            handle.write(f"pinned_version={pinned_version}\n")
+            handle.write(f"new_version={new_version}\n")
+            handle.write(f"new_digest={new_digest}\n")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ytdlp-refresh.yml
+++ b/.github/workflows/ytdlp-refresh.yml
@@ -1,0 +1,210 @@
+# Rebuild the current release on a newer yt-dlp, daily, and republish only the
+# tags that already move.
+#
+# yt-dlp is the one dependency that rots without anyone touching this
+# repository: YouTube changes its player, and a downloader that worked last
+# month answers "No video formats found". The failure is total rather than
+# subtle, and it arrives on YouTube's schedule, not on a release schedule. That
+# is why the weekly watcher exists — but a watcher only shortens the time to
+# *notice*. Between noticing and a maintainer cutting a release, the engine
+# stays broken for everybody, and issue #28 spent six weeks in exactly that gap.
+#
+# What makes this safe is a distinction the tag scheme already draws.
+# `X.Y.Z` is what was released and validated; it is never touched here. `latest`,
+# `X.Y` and `X` already move — CI re-points them at every release — and
+# `deploy/docker-compose.yml` defaults to `latest`. So a self-hoster who wants
+# a working downloader follows a moving tag and gets a fresh yt-dlp within a
+# day; one who wants exactly what shipped pins `X.Y.Z` and is unaffected.
+#
+# The source pin is likewise never edited. `docs/operations/ytdlp-base-image.md`
+# keeps its policy — the Dockerfile is bumped by the maintainer after local
+# validation — and this workflow only passes a newer base as a `--build-arg`,
+# which is the escape hatch that document already describes for trying a
+# candidate. The weekly watcher still files its issue, so the deliberate bump
+# still happens; this just stops users waiting for it.
+
+name: Refresh yt-dlp in the published image
+
+on:
+  schedule:
+    # Daily, 05:43 UTC. Off the hour: GitHub drops scheduled runs when the
+    # whole platform stampedes at :00.
+    - cron: "43 5 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Rebuild even if the pinned base is already current"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ytdlp-refresh
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Is the released image carrying a stale yt-dlp?
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      stale: ${{ steps.check.outputs.update_available }}
+      release: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      moving_tags: ${{ steps.release.outputs.moving_tags }}
+      new_version: ${{ steps.check.outputs.new_version }}
+      new_digest: ${{ steps.check.outputs.new_digest }}
+      pinned_version: ${{ steps.check.outputs.pinned_version }}
+    steps:
+      - name: Find the current release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag=$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)
+          version="${tag#v}"
+          owner=$(echo "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')
+          repo="ghcr.io/${owner}/content"
+          # Only the tags CI already re-points at every release. X.Y.Z is what
+          # was validated and is deliberately absent from this list.
+          case "$version" in
+            *-*) echo "A pre-release is not refreshed: $version" >&2; exit 1 ;;
+            *)
+              major="${version%%.*}"
+              minor="${version%.*}"
+              echo "moving_tags=${repo}:latest,${repo}:${minor},${repo}:${major}" >>"$GITHUB_OUTPUT"
+              ;;
+          esac
+          echo "tag=$tag" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "Release $tag; moving tags will be re-pointed."
+
+      - name: Check out the released tree, not main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+
+      - name: Compare its pin against upstream
+        id: check
+        # The same script the weekly watcher runs, against the *released*
+        # Dockerfile rather than main's — what users are running is what is
+        # being judged.
+        run: python3 .github/scripts/ytdlp_base_check.py
+        env:
+          DOCKERFILE: apps/backend/Dockerfile
+
+  refresh:
+    name: Rebuild ${{ needs.check.outputs.release }} on yt-dlp ${{ needs.check.outputs.new_version }}
+    needs: check
+    if: needs.check.outputs.stale == 'true' || inputs.force
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write # GHCR, via GITHUB_TOKEN — no stored registry secret
+    steps:
+      - name: Check out the released tree
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.check.outputs.release }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build for a boot check
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: content-refresh-check:local
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          provenance: false
+          sbom: false
+
+      # Nothing is published that could not start and could not download. A
+      # daily unattended publish is only defensible if it is gated on the two
+      # things that actually break: the app failing to construct (0.5.0 shipped
+      # unbootable for exactly this reason) and yt-dlp failing to run.
+      - name: The app must build and yt-dlp must answer
+        run: |
+          set -euo pipefail
+          docker run --rm --entrypoint python content-refresh-check:local \
+            -c 'from content.api.app import create_app; create_app(); print("app ok")'
+          got=$(docker run --rm --entrypoint yt-dlp content-refresh-check:local --version)
+          echo "yt-dlp in the rebuilt image: $got"
+          want="${{ needs.check.outputs.new_version }}"
+          # Upstream writes 2026.08.19, yt-dlp reports 2026.08.19 — but an
+          # untagged candidate leaves `want` empty, and then there is nothing
+          # to compare and nothing to publish.
+          if [ -z "$want" ]; then
+            echo "The upstream digest carries no version tag; not publishing." >&2
+            exit 1
+          fi
+          if [ "$got" != "$want" ]; then
+            echo "Expected yt-dlp $want, image reports $got." >&2
+            exit 1
+          fi
+
+      - name: Publish the moving tags
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ needs.check.outputs.moving_tags }}
+          build-args: |
+            YTDLP_BASE_VERSION=${{ needs.check.outputs.new_version }}
+            YTDLP_BASE_DIGEST=${{ needs.check.outputs.new_digest }}
+          labels: |
+            org.opencontainers.image.version=${{ needs.check.outputs.release }}
+            org.opencontainers.image.revision=${{ needs.check.outputs.release }}
+          provenance: false
+          sbom: false
+
+      # Two different things trigger a rebuild and they are worth different
+      # words, for the same reason the watcher's issue titles are: a new yt-dlp
+      # is how YouTube downloads stop working, a rebuilt base at the same
+      # version is distro patches — which is also worth having, since every
+      # CRITICAL/HIGH finding in Saturday's image scan sat in that layer.
+      - name: Say what moved
+        env:
+          WAS: ${{ needs.check.outputs.pinned_version }}
+          NOW: ${{ needs.check.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          if [ "$WAS" = "$NOW" ]; then
+            what="Base rebuilt at the same yt-dlp ($NOW) — distro patches."
+          else
+            what="New yt-dlp: $WAS → $NOW."
+          fi
+          {
+            echo "### yt-dlp refresh"
+            echo
+            echo "$what"
+            echo
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| Release rebuilt | \`${{ needs.check.outputs.release }}\` |"
+            echo "| Tags re-pointed | \`${{ needs.check.outputs.moving_tags }}\` |"
+            echo
+            echo "\`${{ needs.check.outputs.version }}\` was **not** republished:"
+            echo "it is what was released and validated."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/apps/backend/content/api/app.py
+++ b/apps/backend/content/api/app.py
@@ -276,7 +276,13 @@ def create_app(
     settings = settings or settings_from_env()
     store = store or Store(settings.db_path)
     if providers is None:
-        summarizers: list = [OllamaProvider(settings.ollama_url, settings.ollama_model)]
+        summarizers: list = [
+            OllamaProvider(
+                settings.ollama_url,
+                settings.ollama_model,
+                settings.ollama_max_context,
+            )
+        ]
         if settings.anthropic_api_key:
             summarizers.append(
                 CloudSummarizer(

--- a/apps/backend/content/application/collections.py
+++ b/apps/backend/content/application/collections.py
@@ -208,6 +208,11 @@ class CollectionMemberRunner:
                     input_materials=inputs,
                     cancel_check=ctx.cancel_check,
                     on_progress=ctx.on_progress,
+                    # A member's step warns like any other. Forgetting this
+                    # line does not break anything visibly: the default is a
+                    # no-op, so a truncated summary of episode 7 of a playlist
+                    # would simply come back looking clean.
+                    on_warning=ctx.on_warning,
                 ),
             )
             materials[member_step.id] = [

--- a/apps/backend/content/config.py
+++ b/apps/backend/content/config.py
@@ -68,6 +68,13 @@ class ContentSettings:
     allowed_input_roots: tuple[Path, ...] = field(default_factory=tuple)
     ollama_url: str = "http://localhost:11434"
     ollama_model: str = ""  # empty = first installed model (deterministic)
+    # Ceiling on the context window the engine asks Ollama for. The window is
+    # sized per request from the prompt; this bounds it, because the memory is
+    # the daemon's and the engine cannot see how much of it there is. 0 leaves
+    # the choice to the daemon entirely (the pre-0.6.8 behaviour). Raising it
+    # extends how long a recording can be summarised whole — at the cost of RAM
+    # on the machine running Ollama.
+    ollama_max_context: int = 32768
     # Speech-to-text (audio.transcribe) model, used when the optional [stt]
     # extra (faster-whisper) is installed. Absent extra = variants unavailable.
     whisper_model: str = "small"
@@ -530,6 +537,7 @@ def settings_from_env() -> ContentSettings:
         allowed_input_roots=roots,
         ollama_url=os.getenv("CONTENT_OLLAMA_URL", "http://localhost:11434"),
         ollama_model=os.getenv("CONTENT_OLLAMA_MODEL", ""),
+        ollama_max_context=_to_int(os.getenv("CONTENT_OLLAMA_MAX_CONTEXT"), 32768),
         whisper_model=os.getenv("CONTENT_WHISPER_MODEL", "small"),
         pdf_renderer=os.getenv("CONTENT_PDF_RENDERER", "auto").strip().lower(),
         typst_binary=os.getenv("CONTENT_TYPST_BINARY", "typst"),

--- a/apps/backend/content/domain/validation.py
+++ b/apps/backend/content/domain/validation.py
@@ -18,6 +18,14 @@ from content.domain.reserved import check_reserved
 # V1 media output types consume exactly one source and no upstream outputs.
 _SINGLE_SOURCE_TYPES = ("video", "audio", "metadata", "thumbnail", "subtitles")
 
+# The scopes under which one output instance takes one source, and where an
+# arity rule is therefore the engine's to enforce. `each_item` belongs here:
+# it fans over the members of *one* collection source (ADR 0019). Every other
+# scope is about several sources by definition, so the number of inputs is the
+# planner's business — and the planner's answer for all of them today is
+# `scope_not_supported`, which is a promise rather than a rejection.
+_ONE_INSTANCE_SCOPES = ("single", "each_item")
+
 
 class ResolvedInputs(dict):
     """output id -> (source_ids, output_ids) once resolution rules applied."""
@@ -143,6 +151,17 @@ def validate_structure(request: GenerationRequest) -> ValidationResult:
     issues.extend(resolution_issues)
 
     for index, output in enumerate(request.outputs):
+        # Both arity rules below describe **one instance consuming one input**,
+        # which is a property of the scope and not of the output type — the
+        # second one's own message has always said "with scope 'single'".
+        # Applied to every scope, they made the documented answer unreachable:
+        # a client asking for `all_sources`, the scope whose entire purpose is
+        # aggregating several sources, was told `too_many_inputs` — that its
+        # request was malformed — instead of `scope_not_supported`, that it was
+        # well-formed and simply not implemented yet. Those are different
+        # answers, and only the second one tells a client to come back later.
+        if output.scope not in _ONE_INSTANCE_SCOPES:
+            continue
         if output.type in ("transcript", "summary", "translation", "chapters"):
             # These derive from exactly one input: a source, or one upstream
             # output (transcript <- subtitles/audio; summary <- transcript;

--- a/apps/backend/content/providers/ollama.py
+++ b/apps/backend/content/providers/ollama.py
@@ -43,6 +43,43 @@ _AVAILABILITY_TTL_SECONDS = 30.0
 # the acceptable failure here; crying wolf is not.
 _CHARS_PER_TOKEN_FLOOR = 8
 
+# The other direction, used to *size* the window rather than to judge it. French
+# prose measured at 3.77 characters per token on this corpus; 3 over-asks by
+# about a quarter, which costs a little memory and buys the margin. Denser
+# scripts tokenise closer to 1 character per token and will still overflow —
+# `_warn_if_truncated` remains the backstop, by design.
+_CHARS_PER_TOKEN_DENSE = 3
+
+# Room for the answer inside the same window.
+_OUTPUT_HEADROOM_TOKENS = 2048
+
+# Below this, asking for a smaller window than the daemon would have used gains
+# nothing and risks clipping a short prompt.
+_MIN_CONTEXT_TOKENS = 4096
+
+
+def _context_for(prompt: str, ceiling: int) -> int | None:
+    """The window to ask for, or None to leave the choice to the daemon.
+
+    Ollama does not refuse a prompt that does not fit — it truncates it, and it
+    does so on a cliff. Measured on gemma3:4b against a 32 768-token window: a
+    27 304-token prompt was read whole, and a 33 363-token one was read as
+    16 387 — *half* the window, not the window. Two percent over the line costs
+    fifty percent of the source. The same halving reproduced at a requested
+    window of 49 152, where a 50 319-token prompt came back as 24 579.
+
+    So the window is not something to hope about. The daemon's default is one
+    global number chosen with no knowledge of the prompt — and when
+    `OLLAMA_CONTEXT_LENGTH` is unset entirely, that number is 4 096, which
+    halves the transcript of a twenty-minute video. Asking per request is both
+    more correct and cheaper: a short summary no longer reserves a window sized
+    for the longest job the operator once anticipated.
+    """
+    if ceiling <= 0:
+        return None  # explicitly disabled: whatever the daemon decides
+    need = len(prompt) // _CHARS_PER_TOKEN_DENSE + _OUTPUT_HEADROOM_TOKENS
+    return max(_MIN_CONTEXT_TOKENS, min(need, ceiling))
+
 
 def _warn_if_truncated(prompt, payload, model, ctx) -> None:
     """Say so when the daemon read less of the prompt than we sent it.
@@ -73,7 +110,8 @@ def _warn_if_truncated(prompt, payload, model, ctx) -> None:
             f"The model read {read} tokens of a prompt of at least ~{floor}: "
             f"at most {kept}% of the source reached it, and the rest was "
             "silently dropped by the context window. Raise "
-            "OLLAMA_CONTEXT_LENGTH on the daemon, or send a shorter source."
+            "CONTENT_OLLAMA_MAX_CONTEXT (and give the daemon the memory for "
+            "it), or send a shorter source."
         ),
         {
             "provider": "ollama",
@@ -89,9 +127,15 @@ class OllamaProvider:
     location = "local"
     operations = ("text.summarize", "text.translate", "chapters.derive")
 
-    def __init__(self, base_url: str = "http://localhost:11434", model: str = ""):
+    def __init__(
+        self,
+        base_url: str = "http://localhost:11434",
+        model: str = "",
+        max_context: int = 32768,
+    ):
         self.base_url = base_url.rstrip("/")
         self.configured_model = model
+        self.max_context = max_context
         self.tool_version = ""
         self._probe_cache: tuple[float, bool] | None = None
         self._models_cache: tuple[float, list[str]] | None = None
@@ -217,12 +261,16 @@ class OllamaProvider:
         # Blocking single call, bounded by the step timeout. Cooperative
         # cancellation cannot interrupt it mid-call (documented limitation of
         # service runners); the job cancels right after the call returns.
+        options: dict = {"temperature": 0.2}
+        window = _context_for(prompt, self.max_context)
+        if window is not None:
+            options["num_ctx"] = window
         body = json.dumps(
             {
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],
                 "stream": False,
-                "options": {"temperature": 0.2},
+                "options": options,
             }
         ).encode()
         request = urllib.request.Request(

--- a/apps/backend/tests/test_contract_validation.py
+++ b/apps/backend/tests/test_contract_validation.py
@@ -271,3 +271,56 @@ def test_no_public_field_is_accepted_without_being_classified():
         f"reserved: {sorted(unclassified)} — read them in the engine, or add "
         "them to content/domain/reserved.py with a refusal or a warning"
     )
+
+
+# --- multi-source scopes answer "not yet", not "malformed" ----------------------
+
+
+def _two_source_payload(**output):
+    return {
+        "schema_version": "1.0",
+        "sources": [
+            {"id": "a", "type": "text", "content": "one"},
+            {"id": "b", "type": "text", "content": "two"},
+        ],
+        "outputs": [{"id": "s", "from_sources": ["a", "b"], **output}],
+    }
+
+
+@pytest.mark.parametrize("scope", ["all_sources", "each_source", "group"])
+def test_a_multi_source_scope_is_well_formed(scope):
+    """Content is meant to aggregate several sources; `all_sources` is the
+    scope that says so, and Studio already offers up to eight sources.
+
+    Structural validation used to answer `too_many_inputs` here — *your request
+    is malformed* — because an arity rule written for one instance consuming
+    one source was applied to every scope. That made the documented answer
+    unreachable: the contract promises `scope_not_supported`, "valid but not
+    supported by the current execution engine", and a client cannot tell from
+    `too_many_inputs` that the thing it asked for is coming.
+    """
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope=scope))
+    )
+    assert "too_many_inputs" not in codes_of(result)
+    assert result.valid, codes_of(result)
+
+
+@pytest.mark.parametrize("output_type", ["summary", "transcript", "video", "audio"])
+def test_single_scope_still_takes_exactly_one_source(output_type):
+    """The rule is not gone, it is scoped. One instance still consumes one
+    source, which is what `single` means."""
+    result = validate_structure(
+        make_request(_two_source_payload(type=output_type, scope="single"))
+    )
+    assert "too_many_inputs" in codes_of(result)
+
+
+def test_each_item_still_takes_exactly_one_source():
+    """`each_item` fans over the members of *one* collection (ADR 0019), so it
+    keeps the arity rule — and must not become a silent no-op in the planner,
+    which returns early when the count is not one."""
+    result = validate_structure(
+        make_request(_two_source_payload(type="summary", scope="each_item"))
+    )
+    assert "too_many_inputs" in codes_of(result)

--- a/apps/backend/tests/test_llm_truncation.py
+++ b/apps/backend/tests/test_llm_truncation.py
@@ -18,7 +18,7 @@ prose runs nearer 4), so it can miss a truncation but can never invent one.
 
 from __future__ import annotations
 
-from content.providers.ollama import _warn_if_truncated
+from content.providers.ollama import _context_for, _warn_if_truncated
 
 
 class _Ctx:
@@ -44,8 +44,9 @@ def test_a_truncated_prompt_is_reported():
     assert "16387" in message and "silently" in message
     assert details["prompt_eval_count"] == 16_387
     assert details["prompt_tokens_at_least"] == 24_500
-    # The remedy is named, since the ceiling is the daemon's, not the engine's.
-    assert "OLLAMA_CONTEXT_LENGTH" in message
+    # The remedy is named — and it is the engine's own setting, since the engine
+    # now asks for the window rather than inheriting the daemon's.
+    assert "CONTENT_OLLAMA_MAX_CONTEXT" in message
 
 
 def test_a_prompt_that_fitted_says_nothing():
@@ -216,3 +217,71 @@ def test_a_warning_does_not_leak_into_the_next_job(store, settings, providers):
 
     assert store.list_artifacts(noisy)[0]["provenance"]["warnings"] != []
     assert store.list_artifacts(quiet)[0]["provenance"]["warnings"] == []
+
+
+# --- asking for a window that fits, instead of hoping ---------------------------
+#
+# Measured on gemma3:4b, Ollama 0.32, against a 32 768-token window:
+#
+#     prompt 27 304 tokens -> read 27 304   (whole)
+#     prompt 33 363 tokens -> read 16 387   (half the window, plus scaffolding)
+#
+# and again at a requested window of 49 152:
+#
+#     prompt 50 319 tokens -> read 24 579   (half the window, plus scaffolding)
+#
+# Ollama does not degrade gracefully past its window: it keeps half of it. Two
+# percent over the line costs fifty percent of the source, which is why the
+# engine now sizes the window from the prompt rather than inheriting whatever
+# single global number the daemon was started with.
+
+
+def test_a_short_prompt_does_not_reserve_a_long_window():
+    """The cheap direction of the same change: a two-page summary no longer
+    reserves a window sized for the longest job the operator once anticipated."""
+    assert _context_for("x" * 1_000, 32_768) == 4_096
+
+
+def test_the_window_grows_with_the_prompt():
+    # 60 000 characters of prose is ~16 000 tokens; asking for 22 048 clears it
+    # with the margin the 3-characters-per-token estimate is chosen to give.
+    assert _context_for("x" * 60_000, 32_768) == 22_048
+
+
+def test_a_two_hour_transcript_fits_under_the_default_ceiling():
+    """The case the maintainer asked about. ~18 000 words of French speech is
+    about 104 000 characters, measured at 27 400 tokens — under the 32 768
+    default, so it is summarised whole rather than halved."""
+    assert _context_for("x" * 104_000, 32_768) == 32_768
+    # and the estimate is not what limits it: the true need is below the cap
+    assert 104_000 // 3 + 2_048 > 27_400
+
+
+def test_the_ceiling_is_a_ceiling():
+    """Beyond it the engine stops asking for more, and `_warn_if_truncated`
+    becomes the honest answer instead."""
+    assert _context_for("x" * 5_000_000, 32_768) == 32_768
+
+
+def test_zero_hands_the_choice_back_to_the_daemon():
+    """The pre-0.6.8 behaviour, kept reachable: an operator who has tuned
+    OLLAMA_CONTEXT_LENGTH themselves does not want it second-guessed."""
+    assert _context_for("x" * 500_000, 0) is None
+
+
+def test_a_member_of_a_collection_warns_like_any_other_step():
+    """A playlist member runs under its own ExecutionContext, built by
+    `application/collections.py` rather than by the executor. That context
+    forwards `cancel_check` and `on_progress`; when it did not also forward
+    `on_warning`, a truncated summary of episode 7 came back looking clean —
+    the default is a no-op, so nothing failed and nothing was reported."""
+    import inspect
+
+    from content.application import collections
+
+    source = inspect.getsource(collections)
+    built = source.count("ExecutionContext(")
+    forwarded = source.count("on_warning=ctx.on_warning")
+    assert built and forwarded == built, (
+        f"{built} ExecutionContext(s) built here, {forwarded} forward on_warning"
+    )

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -93,6 +93,27 @@ def _actionable(exc: ContentError, base_url: str) -> str:
     return str(exc)
 
 
+# The SDK draws a line Content already believed in: a failure you *anticipated*
+# is reported with your message, and anything else is a crash whose text is
+# withheld from the model. `ToolError` is how a handler says which one this is.
+#
+# Raising a bare `RuntimeError` put every engine failure on the wrong side of
+# that line: from mcp 2.1 an agent asking about an unreachable engine was told
+# "Error executing tool get_config" and nothing more — no URL, no remedy, which
+# is exactly the answer `_actionable` exists to prevent.
+#
+# Imported defensively because the floor is `mcp>=1.2`: the class moved with
+# the fastmcp-to-mcpserver rename, and on a release that has neither, a plain
+# exception is the old behaviour rather than a crash at import time.
+try:  # mcp >= 2.1
+    from mcp.server.mcpserver.exceptions import ToolError
+except ImportError:  # pragma: no cover - depends on the installed mcp
+    try:  # mcp < 2.1
+        from mcp.server.fastmcp.exceptions import ToolError
+    except ImportError:
+        ToolError = RuntimeError  # type: ignore[assignment, misc]
+
+
 def _friendly(fn, client: ContentClient):
     """Wrap one tool so SDK errors surface as guidance rather than errno."""
 
@@ -101,7 +122,17 @@ def _friendly(fn, client: ContentClient):
         try:
             return fn(*args, **kwargs)
         except ContentError as exc:
-            raise RuntimeError(_actionable(exc, client.base_url)) from exc
+            # Anticipated: the engine answered, and what it answered is the
+            # most useful thing the agent can be told.
+            raise ToolError(_actionable(exc, client.base_url)) from exc
+        except (ValueError, TypeError) as exc:
+            # The service's own rejections of a malformed call — "this output
+            # has no 'type'", with the example that fixes it. Anticipated in
+            # the strongest sense: the message exists precisely so the agent
+            # can correct itself without a round trip to the engine. Translated
+            # here rather than raised as ToolError inside `service`, which has
+            # no business importing the MCP SDK.
+            raise ToolError(str(exc)) from exc
 
     return wrapper
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - CONTENT_OPENAI_MODEL=${CONTENT_OPENAI_MODEL:-gpt-4o-mini}
       - CONTENT_OLLAMA_URL=${CONTENT_OLLAMA_URL:-http://host.docker.internal:11434}
       - CONTENT_OLLAMA_MODEL=${CONTENT_OLLAMA_MODEL:-}
+      - CONTENT_OLLAMA_MAX_CONTEXT=${CONTENT_OLLAMA_MAX_CONTEXT:-32768}
       # Speech-to-text model (only used when the image was built with
       # INSTALL_STT=true; see build args above).
       - CONTENT_WHISPER_MODEL=${CONTENT_WHISPER_MODEL:-small}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - CONTENT_OPENAI_MODEL=${CONTENT_OPENAI_MODEL:-gpt-4o-mini}
       - CONTENT_OLLAMA_URL=${CONTENT_OLLAMA_URL:-http://host.docker.internal:11434}
       - CONTENT_OLLAMA_MODEL=${CONTENT_OLLAMA_MODEL:-}
+      - CONTENT_OLLAMA_MAX_CONTEXT=${CONTENT_OLLAMA_MAX_CONTEXT:-32768}
       # Speech-to-text model (only used when the image was built with
       # INSTALL_STT=true; see build args above).
       - CONTENT_WHISPER_MODEL=${CONTENT_WHISPER_MODEL:-small}

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -163,7 +163,7 @@ and this paragraph is the reservation: a future language code spelled
 1. `from_sources` and `from_outputs` list existing ids; otherwise `unknown_source_reference` / `unknown_output_reference`.
 2. The `from_outputs` graph must be acyclic (`dependency_cycle`).
 3. If both are empty: the output consumes **the single source** of the request if `sources` holds only one; otherwise the `role: primary` source if it is unique; otherwise the error `ambiguous_inputs` ("precise from_sources"). No other inference.
-4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise).
+4. An output type imposes input requirements (e.g. `audio` requires exactly one audio-material input per instance in `single` scope: `too_many_inputs` otherwise). **This arity is a property of the scope, not of the type**: it binds `single` and `each_item`, both of which resolve one instance to one source. A scope that is *about* several sources — `each_source`, `all_sources`, `group` — is never `too_many_inputs`; it is well-formed, and today it answers `scope_not_supported`.
 5. A dependency that is declared but technically useless is not an error: it constrains ordering (the step waits) and the provenance. The planner never silently "corrects" the client's declarations.
 
 ### `scope`

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -157,6 +157,7 @@ is in [HomeTube's README](../../apps/web-hometube/README.md#language-preferences
 | **🧠 Providers & LLM runners** | | |
 | `CONTENT_YTDLP_EXTRA_ARGS` | — | The operator's yt-dlp args (trusted), added to every call |
 | `CONTENT_OLLAMA_URL` / `_MODEL` | host / auto | The **local** LLM for `summary`, `translation` and derived `chapters`. Empty model = the first installed one, resolved deterministically and recorded in provenance |
+| `CONTENT_OLLAMA_MAX_CONTEXT` | `32768` | Ceiling on the context window the engine asks Ollama for. The window is sized per request from the prompt; this bounds it, because the memory is the daemon's. Ollama does not degrade gracefully past its window — it keeps **half** of it, so a prompt 2% too long loses 50% of the source. Raising this extends how long a recording can be summarised whole, at the cost of RAM where Ollama runs. `0` hands the choice back to the daemon |
 | `CONTENT_WHISPER_MODEL` | `small` | The speech-to-text model (requires the `[stt]` extra / an image built with `INSTALL_STT=true`) — activates transcript/summary **from audio** |
 | `CONTENT_ANTHROPIC_API_KEY` / `_MODEL` | — / `claude-sonnet-5` | The Anthropic **cloud** LLM for `summary`, `translation` and `chapters` (a key = active; excluded if `privacy.allow_cloud_providers:false`) |
 | `CONTENT_OPENAI_API_KEY` / `_MODEL` | — / `gpt-4o-mini` | The OpenAI **cloud** LLM, same three operations |

--- a/docs/operations/ytdlp-base-image.md
+++ b/docs/operations/ytdlp-base-image.md
@@ -15,12 +15,39 @@ hard, notice automatically, upgrade deliberately.**
 | --- | --- |
 | **Pinned** | An explicit version *and* an immutable digest — never `:latest` |
 | **Detected** | A scheduled workflow compares the pin against upstream every week |
-| **Upgraded** | Only by the maintainer, only after local validation passes |
-| **Never** | No automatic bump, no dependency-update pull request, no auto-merge, no auto-publish |
+| **Upgraded** | The pin in the Dockerfile: only by the maintainer, only after local validation passes |
+| **Refreshed** | The *moving image tags*: daily and unattended, gated on a boot check and a `yt-dlp --version` check |
+| **Never** | No automatic edit to the pin, no auto-merge, and never a republished `X.Y.Z` |
 
-Pull requests are disabled on this repository ([CONTRIBUTING.md](../../CONTRIBUTING.md)),
-so the usual bot-opens-a-PR mechanism is not available and would not be wanted.
-The workflow files **an issue** instead: a notification, not a change.
+The workflow files **an issue** rather than opening a pull request: a
+notification, not a change. Unsolicited pull requests are closed unread
+([CONTRIBUTING.md](../../CONTRIBUTING.md)) — the maintainer's own are the normal
+route for everything else, and Dependabot opens them for pinned actions, but a
+base-image bump wants the local validation below rather than a green tick.
+
+### Why the tags are refreshed and the pin is not
+
+A watcher only shortens the time to *notice*. Between noticing and a release,
+every user's downloader stays broken — issue #28 spent six weeks in that gap,
+and the failure mode is total: "No video formats found", not a degraded result.
+
+What makes an unattended rebuild safe here is a distinction the tag scheme
+already draws. `X.Y.Z` is what was released and validated, and nothing
+republishes it. `latest`, `X.Y` and `X` **already move** — CI re-points them at
+every release, and `deploy/docker-compose.yml` defaults to `latest`. So
+`.github/workflows/ytdlp-refresh.yml` rebuilds the released tree on the newest
+base and re-points only those, which is a promise none of them were making.
+
+The source pin is untouched: the refresh passes the newer base as a
+`--build-arg`, the escape hatch described below. The weekly issue still gets
+filed, and the deliberate bump still happens — this only stops users waiting
+for it.
+
+It also catches something the yt-dlp framing misses. Upstream republishes the
+same yt-dlp version when the distro underneath it is patched, and every
+CRITICAL/HIGH finding in the image scan (ADR 0026) lives in exactly that layer.
+So the trigger is a **digest** change, not a version change, and the run summary
+says which of the two happened.
 
 ## How the pin is written
 

--- a/scripts/gen_readme_diagram.py
+++ b/scripts/gen_readme_diagram.py
@@ -55,11 +55,13 @@ SOURCES = (
     ("Files", "one or many, uploaded"),
     ("Texts", "pasted or batched"),
 )
-# Plural, because `sources` is an array and a single job really does carry
-# several — verified: three sources each with their own outputs validates. The
-# caption is there to stop the plural over-claiming: an output consuming two
-# sources at once is refused (`too_many_inputs`), so the promise is "many
-# sources in one job", not "many sources merged into one file".
+# Plural, because `sources` is documented 1..N and a job really does carry
+# several — Studio offers up to eight. The caption bounds the claim to what
+# runs today: several sources, each producing its own artifacts, in one job.
+# Aggregating several sources into one artifact is the `all_sources` scope,
+# which is designed, documented as "one aggregated result (fan-in)", and not
+# yet implemented — so the engine answers `scope_not_supported` rather than
+# refusing the request.
 SOURCES_NOTE = "several in a single job"
 STEPS = (
     ("Analyze", "understand"),

--- a/tests/test_ytdlp_base_check.py
+++ b/tests/test_ytdlp_base_check.py
@@ -49,3 +49,75 @@ def test_the_body_opens_on_the_distinction_too():
     # Both keep the promise the workflow makes: it never edits anything.
     for body in (upgrade, rebuild):
         assert "Nothing has been changed" in body
+
+
+# --- what the refresh workflow builds with -------------------------------------
+
+
+def test_the_check_exposes_what_a_rebuild_needs(tmp_path, monkeypatch):
+    """The daily refresh rebuilds the released tree on the newer base, so it
+    needs the version and the digest the check resolved — not just a boolean.
+
+    The digest is what Docker resolves and is the authority; the version rides
+    along so the rebuilt image can still say, in a label a human reads, which
+    yt-dlp is inside it.
+    """
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.01.01\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    assert written["pinned_version"] == "2026.01.01"
+    assert written["new_version"] == "2026.08.19"
+    assert written["new_digest"] == "sha256:" + "b" * 64
+
+
+def test_a_rebuilt_base_still_reports_its_version(tmp_path, monkeypatch):
+    """Upstream republishes the same yt-dlp when the distro under it is
+    patched. That is a digest change with no version change, it is still worth
+    rebuilding for — the image scan's findings all live in that layer — and the
+    two must stay distinguishable downstream."""
+    import ytdlp_base_check as mod
+
+    dockerfile = tmp_path / "Dockerfile"
+    dockerfile.write_text(
+        "ARG YTDLP_BASE_VERSION=2026.08.19\n"
+        "ARG YTDLP_BASE_DIGEST=sha256:" + "a" * 64 + "\n"
+        "FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}\n"
+    )
+    out = tmp_path / "out"
+    out.write_text("")
+
+    monkeypatch.setattr(mod, "DOCKERFILE", str(dockerfile))
+    monkeypatch.setattr(mod, "upstream_digest", lambda: "sha256:" + "b" * 64)
+    monkeypatch.setattr(mod, "version_for", lambda digest: "2026.08.19")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(out))
+    monkeypatch.chdir(tmp_path)
+
+    mod.main()
+
+    written = dict(
+        line.split("=", 1) for line in out.read_text().splitlines() if "=" in line
+    )
+    assert written["update_available"] == "true"
+    # Same version on both sides: the refresh must still be able to tell the
+    # reader this was a rebuild rather than a new yt-dlp.
+    assert written["pinned_version"] == written["new_version"] == "2026.08.19"


### PR DESCRIPTION
One branch, five commits, one review — replacing #54, #58, #59 and #61, now closed. Read it commit by commit; each carries its own reasoning.

`make validate` green (805 backend tests). Rebased on `main`, merges clean.

**The text-to-speech work is deliberately not here.** It is complete and proven, but it destabilises a concurrency test (details at the bottom); it waits on branch `speech-output` rather than making `main` red half the time.

---

### 1. `Say ToolError, so the agent still hears why` — **merge this even if you reject everything else**

**`main` is red right now.** `mcp 2.1.0` was published at 19:04 UTC on the 24th; the dependency is `mcp>=1.2` — a floor, no ceiling, no lockfile — so CI resolved it and every branch went red without a line of MCP code changing. Main was green at 14:23, before the release.

The SDK change is a good one and we were on the wrong side of it: 2.1.0 distinguishes *a failure you anticipated* from *a crash*. Raise `ToolError` and your message reaches the model; raise anything else and the model is told only `Error executing tool get_config`. Every engine failure here raised a bare `RuntimeError`, so an agent asking about an unreachable engine lost the URL and the remedy — precisely what `_actionable` exists to prevent.

Verified green against **2.1.0 and 2.0.0**. This is ADR 0026's finding 1 arriving in person.

### 2. `Several sources is well-formed, and the engine now says so`

You were right and I was wrong. `sources` is documented 1..N, `all_sources` is *"one aggregated result (fan-in)"*, Studio offers up to eight. But two arity rules written for one-instance-one-input were applied to **every** scope — the second's own message even said `"with scope 'single'"` while never checking it. So a client asking for `all_sources` got `too_many_inputs`: *your request is malformed*. It wasn't.

The contract promises `scope_not_supported` and the planner emits it; it was simply unreachable, because structural validation runs first. Now bound to the scopes it describes. Nothing that runs became permissible.

### 3. `Refresh yt-dlp daily in the tags that already move`

A watcher only shortens time-to-*notice* — issue #28 spent six weeks between noticing and a release, with every user's downloader dead. What makes an unattended rebuild safe is a distinction the tag scheme already drew: **`X.Y.Z` is never republished**; `latest`, `X.Y`, `X` already move at every release, and `deploy/docker-compose.yml` defaults to `latest`.

Triggered on a *digest* change, not a version change — so it also picks up the base-layer CVEs the image scan could only advise about. Gated on the app constructing and `yt-dlp --version` matching.

### 4–5. `Ask Ollama for a window that fits` + deploy regen

Ollama doesn't degrade past its window — **it keeps exactly half of it**. Measured: 27 304 tokens read whole, 33 363 read as 16 387. Two percent over costs fifty percent of the source. Content sent no `num_ctx` at all, so the window was whatever the daemon was started with — 4096 when unset, which halves a twenty-minute video.

Also closes a hole the truncation warning shipped with: playlist members ran under an `ExecutionContext` that didn't forward `on_warning`, so a truncated summary of episode 7 came back looking clean.

---

## Two things I did not fix

**The dependency question.** A floor with no ceiling and no lockfile means any release anywhere can turn every branch red between two runs of identical code. That happened. ADR 0026 finding 1 now has an incident behind it.

**A real race in fail-fast member handling.** `test_fail_fast_lets_running_members_finish_and_starts_no_new_ones` fails when member 3 starts after member 1's failure should have stopped it. Measured across runs: **6/6 green without the speech commit, 2/8 with it** — so the race is pre-existing and the speech commit widens the window. Never reproducible locally (20+ runs, under CPU load, with an aggressive GIL switch interval).

Member steps *are* `required`, so `request_stop()` does fire before the worker frees; by that reading member 3 cannot start, and it does. Finding out why needs CI instrumentation rather than more guessing — I ran four isolation experiments that each "explained" it until the next run contradicted them. Written up in `work/discoveries.md`.