### PR TITLE
A timestamp was failing a finished copy on CIFS/SMB

### DIFF
--- a/apps/backend/content/storage/paths.py
+++ b/apps/backend/content/storage/paths.py
@@ -36,6 +36,29 @@ def safe_segment(value: str, kind: str = "identifier") -> str:
     return value
 
 
+def _copy_preserving_what_it_can(source: Path, target: Path) -> None:
+    """Copy the bytes, then carry the metadata across if the filesystem lets us.
+
+    ``shutil.copy2`` is ``copyfile`` followed by ``copystat``, and ``copystat``
+    calls ``os.utime`` — which a CIFS/SMB mount refuses outright with EPERM.
+    Both callers below stage *beside the destination*, which on such a
+    deployment is the share itself: the bytes landed, the timestamp call
+    raised, and the publish failed with the copy already complete. A finished
+    artifact was lost to a modification time.
+
+    So the two halves are separated. The copy must succeed; the metadata is an
+    improvement on top of it. Still attempted rather than dropped, because
+    timestamps are worth preserving wherever they are allowed — and not
+    logged, because nothing in this module logs and a share refusing ``utime``
+    is expected rather than exceptional.
+    """
+    shutil.copyfile(source, target)
+    try:
+        shutil.copystat(source, target)
+    except OSError:
+        pass
+
+
 def publish_file(source: Path, destination: Path, *, overwrite: bool = False) -> Path:
     """Publish a completed file to its final path (INV-STORAGE-007/008).
 
@@ -55,7 +78,7 @@ def publish_file(source: Path, destination: Path, *, overwrite: bool = False) ->
         # Cross-filesystem: stage next to the destination, then rename in place.
         staged = destination.parent / f".{destination.name}.partial"
         try:
-            shutil.copy2(source, staged)
+            _copy_preserving_what_it_can(source, staged)
             os.replace(staged, destination)
         finally:
             staged.unlink(missing_ok=True)
@@ -104,7 +127,7 @@ def stage_beside(source: Path, directory: Path, *, move: bool = False) -> Path:
         if move:
             publish_file(Path(source), staged, overwrite=True)
         else:
-            shutil.copy2(Path(source), staged)
+            _copy_preserving_what_it_can(Path(source), staged)
     except BaseException:
         staged.unlink(missing_ok=True)
         raise

--- a/apps/backend/tests/test_storage.py
+++ b/apps/backend/tests/test_storage.py
@@ -4,13 +4,20 @@ Covers path safety, the tmp/work/artifact lifecycles, atomic publication and
 the cache-disabled default (no inter-job reuse in V1).
 """
 
+import errno
+
 import pytest
 
 from content.analysis.service import AnalysisService
 from content.application.submit import submit_generation
 from content.execution.executor import JobExecutor
 from content.storage.layout import JobStorage
-from content.storage.paths import StoragePaths, publish_file, safe_segment
+from content.storage.paths import (
+    StoragePaths,
+    publish_file,
+    safe_segment,
+    stage_beside,
+)
 from tests.conftest import make_request, minimal_payload
 
 # --- path safety (INV-STORAGE-006) ---------------------------------------------
@@ -110,6 +117,103 @@ def test_publish_file_cross_filesystem_fallback(tmp_path, monkeypatch):
     assert dest.read_bytes() == b"cross-fs"
     assert not src.exists()
     assert not (dest.parent / f".{dest.name}.partial").exists()
+
+
+def _refusing_copystat():
+    """What a CIFS/SMB mount does to ``os.utime``."""
+
+    def refuse(*_args, **_kwargs):
+        raise PermissionError(errno.EPERM, "Operation not permitted")
+
+    return refuse
+
+
+def _flaky_replace(paths_mod):
+    """os.replace that fails the direct move once, then behaves."""
+    real_replace = paths_mod.os.replace
+    calls = {"n": 0}
+
+    def flaky(a, b):
+        calls["n"] += 1
+        if calls["n"] == 1:  # the direct move, as across a mount point
+            raise OSError(errno.EXDEV, "Cross-device link")
+        return real_replace(a, b)  # the staged rename succeeds
+
+    return flaky
+
+
+def test_publish_file_survives_a_destination_that_refuses_timestamps(
+    tmp_path, monkeypatch
+):
+    """A CIFS/SMB share refuses ``utime`` outright, and the copy staged beside
+    the destination lives *on that share*. ``copy2`` is ``copyfile`` plus
+    ``copystat``, so the bytes landed and the call raised anyway — a timestamp
+    failing a finished copy, and no artifact publishable to such a mount.
+
+    Preserved metadata is worth having and is not worth a failed delivery.
+    """
+    import content.storage.paths as paths_mod
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"finished media")
+    dest = tmp_path / "share" / "dest.bin"
+
+    monkeypatch.setattr(paths_mod.os, "replace", _flaky_replace(paths_mod))
+    monkeypatch.setattr(
+        paths_mod.shutil,
+        "copystat",
+        _refusing_copystat(),
+    )
+
+    publish_file(src, dest)
+
+    assert dest.read_bytes() == b"finished media"
+    assert not src.exists()  # consumed, as on any successful publish
+    assert not (dest.parent / f".{dest.name}.partial").exists()
+
+
+def test_stage_beside_survives_a_destination_that_refuses_timestamps(
+    tmp_path, monkeypatch
+):
+    """The same defect on the copy branch of ``stage_beside``: it stages into
+    the caller's directory, which is the share."""
+    import content.storage.paths as paths_mod
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"payload")
+    monkeypatch.setattr(paths_mod.shutil, "copystat", _refusing_copystat())
+
+    staged = stage_beside(src, tmp_path / "share", move=False)
+
+    assert staged.read_bytes() == b"payload"
+    assert src.exists()  # move=False leaves the source alone
+    assert staged.parent == tmp_path / "share"
+
+
+def test_the_cross_filesystem_publish_still_preserves_timestamps(tmp_path, monkeypatch):
+    """The fix tolerates a refusal; it must not stop *asking*. Dropping
+    ``copystat`` everywhere would quietly lose mtimes on every filesystem that
+    was happy to keep them."""
+    import content.storage.paths as paths_mod
+
+    src = tmp_path / "src.bin"
+    src.write_bytes(b"cross-fs")
+    dest = tmp_path / "sub" / "dest.bin"
+
+    seen: list[str] = []
+    real_copystat = paths_mod.shutil.copystat
+
+    def recording_copystat(a, b, **kwargs):
+        seen.append(str(b))
+        return real_copystat(a, b, **kwargs)
+
+    monkeypatch.setattr(paths_mod.os, "replace", _flaky_replace(paths_mod))
+    monkeypatch.setattr(paths_mod.shutil, "copystat", recording_copystat)
+
+    publish_file(src, dest)
+
+    assert seen, "copystat was never attempted; timestamps are no longer preserved"
+    assert dest.read_bytes() == b"cross-fs"
 
 
 # --- job lifecycles (INV-STORAGE-003/004/005) ----------------------------------


### PR DESCRIPTION
**For review — please do not merge on my say-so.**

Nobody whose delivery directory is a CIFS/SMB share could publish **any** artifact.

## The bug, reproduced before it was touched

`publish_file()` moves a finished file to its final path — atomically when source and destination share a filesystem. A delivery share is a different mount, so it takes the other branch: stage beside the destination, then rename in place.

That staged copy used `shutil.copy2`, which is `copyfile` **plus** `copystat` — and `copystat` calls `os.utime`, which a CIFS/SMB mount refuses outright with `EPERM`. The staged file lives *on the share*, so the bytes landed and the call raised anyway. The `finally` removed the staged file and the publish failed with the copy already complete.

Confirmed first, rather than taken on description:

```
REPRODUIT : PermissionError [Errno 1] Operation not permitted
  destination créée   : False
  source survit       : True
  .partial résiduel   : []
```

`stage_beside(move=False)` reproduces identically.

**It degrades well.** The source survives and nothing partial is left behind, so no data is lost or corrupted — the publish simply never happens. Worth stating, because it means no one's library is damaged; they just can't deliver to it.

## The fix

The two halves are separated: the copy must succeed, the metadata is an improvement on top of it. Both call sites go through one helper rather than repeating the reasoning.

Two decisions worth your eye:

- **`copystat` is still attempted, not dropped.** Timestamps are worth preserving wherever the filesystem allows it. A test pins that it is still called on the ordinary cross-filesystem path, so the fix cannot quietly degrade into "stop preserving mtimes everywhere".
- **The swallowed `OSError` is not logged.** Nothing in `content/storage` logs anything, and a share refusing `utime` is expected rather than exceptional — introducing that package's first logger for this would be a larger change than the bug. A comment carries the reasoning instead. Say the word if you'd rather have a debug line.

## Tests

`test_publish_file_cross_filesystem_fallback` already existed but only made `os.replace` raise `EXDEV` — it never made `copystat` fail, which is exactly how this shipped.

Three new tests, **checked against the unpatched module first**:

```
FAILED test_publish_file_survives_a_destination_that_refuses_timestamps
FAILED test_stage_beside_survives_a_destination_that_refuses_timestamps
2 failed  —  PermissionError: [Errno 1] Operation not permitted
```

A test that passes against the broken code proves nothing, and that is the failure mode that let this ship.

`make validate` green — 808 backend tests.

## Knowingly out of scope

`shutil.copy2` is left alone in `providers/ytdlp.py:433` (cookies into the job workdir) and `providers/ffmpeg.py:454` (remux into `ctx.workdir`). Both target the **local work directory**, never the delivery share, so neither can meet a mount that refuses `utime`. Changing them would be churn without a failure behind it.

## Credit

Same root cause as **HomeTube #122**, fixed there in v2.12.1. Reported and diagnosed by **@stanthewizzard**.

`Refs #122` rather than `Fixes` — closing a human-reported issue is a person's call.

---

**Unrelated, flagged not done:** the `hometube/` folder at the repo root is a vendored HomeTube v2.9.1 copy. Nothing builds it — `content-hometube` comes from `apps/web-hometube/Dockerfile`, and `hometube/` is in neither CI nor the Makefile. It still carries an old widget-key bug that cannot trigger there. Worth deleting, as its own change rather than bundled into a delivery fix.