### PR TITLE
The yt-dlp refresh ran the released checker, not the current one

### DIFF
--- a/.github/workflows/ytdlp-refresh.yml
+++ b/.github/workflows/ytdlp-refresh.yml
@@ -82,19 +82,47 @@ jobs:
           echo "version=$version" >>"$GITHUB_OUTPUT"
           echo "Release $tag; moving tags will be re-pointed."
 
-      - name: Check out the released tree, not main
+      # main, not the tag. The *pin* being judged belongs to the release; the
+      # checker reading it is tooling and belongs to main. Conflating the two
+      # is what broke this job for three nights: it ran v0.6.7's copy of the
+      # script, which predates the outputs the rebuild needs, so `new_version`
+      # and `new_digest` arrived empty and docker was handed
+      # `jauderho/yt-dlp:@`. `update_available` existed back then and still
+      # came through, which is exactly why the check job went on passing.
+      - name: Check out main — the checker is tooling, not the artifact
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.release.outputs.tag }}
+          fetch-depth: 0 # the release tag has to be reachable
+
+      - name: Take the released Dockerfile, and only that
+        run: |
+          set -euo pipefail
+          git show "${{ steps.release.outputs.tag }}:apps/backend/Dockerfile" \
+            > released.Dockerfile
+          echo "Judging the pin from ${{ steps.release.outputs.tag }}:"
+          grep -E '^ARG YTDLP_BASE_' released.Dockerfile
 
       - name: Compare its pin against upstream
         id: check
-        # The same script the weekly watcher runs, against the *released*
-        # Dockerfile rather than main's — what users are running is what is
-        # being judged.
         run: python3 .github/scripts/ytdlp_base_check.py
         env:
-          DOCKERFILE: apps/backend/Dockerfile
+          DOCKERFILE: released.Dockerfile
+
+      # A guard, because the failure this fixes was silent here and loud four
+      # steps later, in docker's words rather than ours.
+      - name: An update with nothing to build with is a broken check
+        if: steps.check.outputs.update_available == 'true'
+        env:
+          NEW_VERSION: ${{ steps.check.outputs.new_version }}
+          NEW_DIGEST: ${{ steps.check.outputs.new_digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NEW_DIGEST" ]; then
+            echo "::error::the check reported an update but resolved no digest;" \
+                 "refusing to build with empty --build-args"
+            exit 1
+          fi
+          echo "Will rebuild on ${NEW_VERSION:-(untagged)} $NEW_DIGEST"
 
   refresh:
     name: Rebuild ${{ needs.check.outputs.release }} on yt-dlp ${{ needs.check.outputs.new_version }}


### PR DESCRIPTION
Fixes the daily "Refresh yt-dlp in the published image" failures — three in a row, most recently 17:42 UTC today.

## Why it fails, every night, identically

```
docker buildx build --build-arg YTDLP_BASE_VERSION= --build-arg YTDLP_BASE_DIGEST=
ERROR: failed to parse stage name "jauderho/yt-dlp:@": invalid reference format
```

Both build-args are **empty**, so `FROM jauderho/yt-dlp:${VERSION}@${DIGEST}` collapses to `:@`.

The check job checked out the **release tag** and ran *that tree's* `ytdlp_base_check.py`. v0.6.7's copy predates the outputs the rebuild needs:

| | v0.6.7's script | main's script |
| --- | --- | --- |
| `update_available` | ✅ | ✅ |
| `issue_title` | ✅ | ✅ |
| `new_version` | ❌ | ✅ |
| `new_digest` | ❌ | ✅ |
| `pinned_version` | ❌ | ✅ |

`update_available` existed back then and still came through — which is exactly why the **check job kept passing** and the job died four steps later, in docker's words rather than ours.

## The design mistake, named

The *pin* being judged belongs to the release. The *checker* reading it is tooling and belongs to `main`. I conflated "judge what users are running" with "run what users are running", and wrote a comment congratulating myself for it.

The job now checks out `main`, lifts only the released Dockerfile out of the tag with `git show`, and runs the current checker against it. The rebuild still builds the released tree — that part was never in question.

## And a guard

If the check reports an update but resolves no digest, the job now stops there and says so, rather than handing docker empty arguments and letting a reference-format error do the explaining.

## Verified

Ran the corrected sequence locally against v0.6.7's Dockerfile:

```
pinned   : 2026.08.19  sha256:11c9231b…
upstream : latest      sha256:ecbd6b94…
new_version=2026.08.19
new_digest=sha256:ecbd6b949dd54a77ec70622c99b208960686431972bd82592320e20e7b2a436d
```

Non-empty, which is the whole fix. Note this is the *rebuilt-base* case — same yt-dlp version, new image, i.e. distro patches — which the workflow already reports distinctly from a genuine version bump.

## Worth saying

A workflow that only runs on a schedule is untested until the schedule runs it. That is the other half of how this shipped: CI never exercised it, because nothing triggers it on push.

**Merging this means tomorrow's 05:43 UTC run will actually publish** — re-pointing `latest`, `0.6` and `0` at a rebuild of v0.6.7 on the current base. `0.6.7` itself is untouched, as designed. Happy to dispatch it manually first if you'd rather watch it once before it runs unattended.