### PR TITLE
The base stopped shipping pip, so install into a venv

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -59,8 +59,27 @@ RUN if [ "$YTDLP_SELF_UPDATE" = "true" ]; then \
 # the update procedure reads it back from a running container.
 RUN yt-dlp --version
 
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_BREAK_SYSTEM_PACKAGES=1 \
+# Install into a virtual environment, not the base's Python.
+#
+# The base stopped shipping pip and marked its system Python
+# externally-managed (PEP 668), so installing there is now both impossible and
+# refused by policy — `pip: not found`, and behind it an EXTERNALLY-MANAGED
+# marker that would have said no anyway. `PIP_BREAK_SYSTEM_PACKAGES` used to
+# cover the second half; nothing covers the first.
+#
+# A venv is what PEP 668 points at, and it asks nothing of the base beyond
+# `venv` itself, which is stdlib. Verified against both the pinned base and the
+# current one: `python3 -m venv` yields a working pip on each, so this is not a
+# fix that only works after the next bump.
+#
+# Everything downstream resolves through it — the dependency install, the
+# optional STT extra, and the CMD that starts the app — because it is first on
+# PATH. yt-dlp and ffmpeg are untouched: they are base binaries, and yt-dlp
+# pins its own interpreter in its shebang.
+RUN python3 -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
The daily refresh has been failing on `pip: not found`, exit 127. This one is **not** a workflow bug — upstream `jauderho/yt-dlp` changed underneath us.

## What changed upstream

Two things, either of which alone would break the build:

| | pinned base `11c9231b…` | current base `ecbd6b94…` |
| --- | --- | --- |
| `pip` binary | `/usr/bin/pip` | **absent** |
| `python3 -m pip` | pip 26.1.2 | **No module named pip** |
| `EXTERNALLY-MANAGED` (PEP 668) | — | **present** |

So pip is gone, *and* the system Python is now marked externally managed — meaning even with pip present, installing into it would be refused by policy. `PIP_BREAK_SYSTEM_PACKAGES=1` was already set in this Dockerfile, which covered the second half before anyone met the first.

`ensurepip` is not the escape: the module is there, but bootstrapping it hits the same PEP 668 refusal (`error: externally-managed-environment`).

## The fix

A virtual environment — which is what PEP 668 actually points at. It asks nothing of the base beyond `venv` from the standard library, and `/opt/venv/bin` first on `PATH` carries it through the dependency install, the optional STT extra, and the `CMD` that starts the app.

`yt-dlp` and `ffmpeg` are untouched: base binaries, and yt-dlp pins its own interpreter in its shebang.

## Built and run, not reasoned about

Against **both** bases, because a fix that only works after the next bump is not a fix:

```
current base   app ok · yt-dlp 2026.08.19 · python /opt/venv/bin/python3 · deps importable · ffmpeg 8.1.2
pinned  base   app ok · yt-dlp 2026.08.19 · python /opt/venv/bin/python3 · deps ok        · typst 0.15.1
```

`make validate` green.

## The part that matters more than the refresh

**CI is green today only because releases build against the pinned digest.** The next time that pin is bumped — which the weekly watcher keeps asking for — `docker compose build content` would have failed exactly this way on your machine, with nothing to indicate upstream had changed the contract.

The refresh job found it first. That is the job working, not the job failing.

## Out of scope, and pre-existing

`INSTALL_STT=true` fails on musl/arm64 because `ctranslate2` publishes no wheel for it. Verified **identical with and without this change**, on the pinned base. Off by default, so nothing shipped is affected.