### PR TITLE
Version 0.6.8

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.7"
+    org.opencontainers.image.version="0.6.8"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.7"
+version = "0.6.8"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.7"
+version = "0.6.8"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.7"]
+dependencies = ["content-sdk==0.6.8"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -139,7 +139,7 @@ def _friendly(fn, client: ContentClient):
 
 def build_server(client: ContentClient | None = None) -> MCPServer:
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.7", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.6.8", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.7"
+version = "0.6.8"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.7", "mcp>=1.2"]
+dependencies = ["content-sdk==0.6.8", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.7"
+version = "0.6.8"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.6.8.md
+++ b/docs/releases/v0.6.8.md
@@ -1,0 +1,70 @@
+The image builds again on a base that changed underneath it, and delivering to
+a network share works.
+
+## Why this one matters
+
+Two independent breakages, both invisible from inside a green CI.
+
+**The base image stopped shipping pip.** Upstream `jauderho/yt-dlp` removed pip
+and marked its Python externally managed (PEP 668), so `pip install` there is
+now both absent and refused by policy. Nothing broke for anyone running 0.6.7 —
+that image was already built — but the *next* build of it could not succeed.
+The daily refresh that keeps `latest` on a current yt-dlp had been failing on
+`pip: not found` since, and a maintainer bumping the base pin would have met
+the same wall with nothing to say the contract had changed.
+
+Dependencies now install into a virtual environment, which is what PEP 668
+points at and asks nothing of the base beyond the standard library. Verified by
+building and running against both the old base and the current one.
+
+**Publishing to a CIFS/SMB share was impossible.** `publish_file` stages a copy
+beside the destination and renames it — and on a share, "beside the
+destination" is the share. It used `shutil.copy2`, which is `copyfile` plus
+`copystat`, and `copystat` calls `utime`, which CIFS/SMB refuses outright. The
+bytes landed and the call raised anyway, so the staged file was removed and the
+publish failed with the copy already complete. A modification time was failing a
+finished artifact.
+
+It degraded honestly — the source survived, nothing partial was left behind, no
+library was corrupted — but nobody delivering to a network share could publish
+anything at all. The copy and the metadata are now separate operations:
+timestamps are still preserved wherever the filesystem allows it, and a refusal
+no longer costs the artifact.
+
+Same root cause as HomeTube #122, fixed there in v2.12.1. Reported and
+diagnosed by **@stanthewizzard**.
+
+## Also in this release
+
+- The yt-dlp refresh ran the *released* copy of its own checker rather than the
+  current one, so it handed Docker empty build arguments and died on
+  `jauderho/yt-dlp:@`. The pin being judged belongs to the release; the checker
+  reading it is tooling and belongs to main.
+- When the released tree genuinely cannot be rebuilt on a newer base, that
+  refresh now files it as an issue and ends green instead of going red every
+  morning about something the reader cannot act on. Everything after the build —
+  the boot check, the publish — is still a hard failure.
+- The OpenSSF Scorecard badge read "invalid repo path" while the data was there
+  all along: the published URL redirects to shields.io, which lowercases the
+  path, and the Scorecard API is case-sensitive about `LatentNoise`.
+
+## Validated before shipping
+
+- `make validate` green — 808 backend tests, plus the SDK, CLI, MCP and UI
+  suites.
+- The image built **and run** against both the pinned base and the current one:
+  the app constructs, `python3` resolves inside the venv, yt-dlp answers
+  2026.08.19, ffmpeg 8.1.2 and Typst 0.15.1 still work.
+- The CIFS/SMB fix has three new tests, checked against the unpatched module
+  first — they fail there with `PermissionError: [Errno 1] Operation not
+  permitted`. One of them pins that `copystat` is *still* called on the ordinary
+  cross-filesystem path, so tolerating a refusal cannot quietly become "stop
+  preserving timestamps everywhere".
+
+## Upgrading
+
+Nothing to change. `docker compose pull && docker compose up -d`, or pin
+`0.6.8` if you follow exact versions.
+
+If your delivery directory is a CIFS/SMB mount, this is the release that makes
+it work.

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.7"
+version = "0.6.8"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.7",
+      "version": "0.6.8",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The bump and the notes. Nothing is released by merging this — the tag comes after.

Ships two independent breakages, both invisible from inside a green CI:

- **The base image stopped shipping pip** (and marked its Python externally managed, PEP 668). Nobody running 0.6.7 was affected — that image was already built — but the *next* build of it could not succeed, the daily refresh had been failing on `pip: not found`, and bumping the base pin would have hit the same wall. Dependencies now install into a venv.
- **Publishing to a CIFS/SMB share was impossible.** `copystat` calls `utime`, which the share refuses, so the bytes landed and the call raised anyway. Credited to **@stanthewizzard**, same root cause as HomeTube #122.

Plus the refresh workflow fixes and the Scorecard badge.

`make validate` green — 808 backend tests. Version consistent across all 17 declarations.

Not included: **#63**, which is still marked do-not-merge — the fail-fast race is understood but not closed.