### PR TITLE
poll_after in get_job, and the streamable-http transport

### DIFF
--- a/apps/mcp/README.md
+++ b/apps/mcp/README.md
@@ -65,7 +65,9 @@ for air-gapped installs (`uv tool install ./content_mcp-<v>-py3-none-any.whl
 ## Connect it to your engine
 
 One environment variable: `CONTENT_API_URL` (default `http://localhost:8010`).
-The server speaks stdio — your MCP client spawns it; you never run it by hand.
+The server speaks stdio by default — your MCP client spawns it; you never run
+it by hand. A second transport, streamable-http, is available for clients
+that cannot spawn a process — see *Why stdio, and not an HTTP endpoint* below.
 
 ### Why stdio, and not an HTTP endpoint
 
@@ -97,15 +99,30 @@ Two things follow from it, both worth having:
   laptop.
 
 **What stdio cannot do**, plainly: serve a client that cannot spawn a process on
-your machine — Open WebUI in a container, LibreChat, a hosted web UI. For those,
-[`mcpo`](https://github.com/open-webui/mcpo) bridges an stdio MCP server to
-HTTP/OpenAPI today, and Open WebUI documents it as its own path.
+your machine — Open WebUI in a container, LibreChat, a hosted web UI. For
+those, set `CONTENT_MCP_TRANSPORT=streamable-http` (the `mcp` library's own
+implementation — this server adds no HTTP code of its own) and point the
+client at `http://127.0.0.1:8770/mcp` by default:
 
-An HTTP transport may still come as a **second mode** — the SDK does
-`streamable-http` with one parameter — for the inverse case: sources that are
-already remote, and a client that cannot spawn. It would ship bound to loopback
-by default, and it would have to refuse local paths outright rather than
-silently resolve them somewhere else. stdio stays the default either way.
+```bash
+CONTENT_MCP_TRANSPORT=streamable-http CONTENT_API_URL=http://localhost:8010 content-mcp
+```
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `CONTENT_MCP_TRANSPORT` | `stdio` | `stdio` or `streamable-http` |
+| `CONTENT_MCP_HTTP_HOST` | `127.0.0.1` | streamable-http only — **loopback**. Widening it (`0.0.0.0`, a LAN address) is something you ask for explicitly; this server will not default it open |
+| `CONTENT_MCP_HTTP_PORT` | `8770` | streamable-http only |
+
+The trade named above is real, and streamable-http does not escape it: **local
+file paths are refused outright** rather than resolved on whatever host
+happens to be running the server. `analyze_source("~/report.pdf")` works over
+stdio (the machine running the server is yours) and is rejected over
+streamable-http (the server may be reachable from a machine that is not
+yours, and "this machine" would silently mean the wrong one). Sources that are
+already remote — a URL — are unaffected either way. [`mcpo`](https://github.com/open-webui/mcpo)
+remains an option too, if you would rather bridge an stdio server than run
+this mode.
 
 ### Claude Code
 
@@ -177,7 +194,7 @@ Stated plainly, because finding out by trying is a bad first impression.
 | Not available | Why, and what to do instead |
 | --- | --- |
 | **MCP prompts** | Not provided. The tool descriptions and the server instructions carry the guidance instead. |
-| **Live progress** | `get_job` is a status poll. The engine has an event stream, but no MCP notification carries it — a long download is opaque until it ends. |
+| **Live progress** | `get_job` is a status poll (it does suggest a `poll_after` pace, but not progress within a step). The engine has an event stream, but no MCP notification carries it — a long download is opaque until it ends. |
 | **Job logs** | Not exposed. `get_job` gives the failing step and its reason, which is what an agent can act on; the raw logs stay on the engine. |
 | **Retrying only what failed** | `retry_job` re-runs the whole request. A decision is pending (ADR 0025). |
 | **`.docx`, `.epub`, `.odt`, `.rtf`** | Recognised and refused — each needs its own reader. |
@@ -202,9 +219,6 @@ implemented; each links to where the decision lives.
   ([ADR 0023](../../docs/architecture-decisions/0023-retention-and-reclaiming-disk.md),
   proposed).
 - **More document readers, and OCR** — the formats listed as refused above.
-- **An HTTP transport as a second mode** — for clients that cannot spawn a
-  process (Open WebUI, hosted UIs). Not a replacement: see *Why stdio* above
-  for what it would cost, and `mcpo` for what works today.
 
 Something you need that is not here? The gap list is the roadmap's front door:
 [open an issue](https://github.com/LatentNoise/content/issues).
@@ -216,7 +230,7 @@ Something you need that is not here? The gap list is the roadmap's front door:
 | `analyze_source` | Analyze a URL: what it is + what can be produced |
 | `list_capabilities` | Resolve the capabilities for an analyzed source |
 | `generate` | Start a job producing outputs from an `analysis_id`; an output spec may carry `delivery` (`mode`/`folder`/`filename`, ADR 0018) |
-| `get_job` | Job status; once terminal, its artifacts — user-facing names (ADR 0017) and `delivered_path` in the server library |
+| `get_job` | Job status; once terminal, its artifacts — user-facing names (ADR 0017) and `delivered_path` in the server library. Carries `poll_after` (seconds, `null` once terminal): a heuristic for how long to wait before calling again, not a promise |
 | `cancel_job` | Cooperative cancellation |
 | `retry_job` | Run a finished job's request again, as a new job. The **whole** request — see *What is coming* for the finer version |
 | `list_jobs` | Recent jobs |
@@ -301,7 +315,10 @@ A path you give `analyze_source` is a path on the machine running **this
 server**, never on the engine: the file is read here and uploaded, which is the
 only way a local file becomes usable by an engine running elsewhere. Identical
 path strings on two machines do not imply identical filesystems, so the path is
-never passed through untouched.
+never passed through untouched. That only holds when "this server" is
+unambiguous, which is why it is stdio-only: over streamable-http, where the
+server may run on a different machine than the caller, a local path is
+refused rather than read on the wrong host.
 
 `download_artifact` is the mirror image — it brings a finished artifact back to
 this machine, bounded by `CONTENT_MCP_DOWNLOAD_DIR` (see above).

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -2,7 +2,16 @@
 
 It exposes **intention-level** Tools (not one-per-endpoint) and read-only
 Resources, each delegating to ``service.py`` which speaks only the SDK. No REST,
-no business logic here. stdio transport (HTTP can come later).
+no business logic here.
+
+Two transports: stdio (the default — spawned by the client, one caller, no
+port) and streamable-http (CONTENT_MCP_TRANSPORT=streamable-http — for a
+client that cannot spawn a subprocess, e.g. OpenWebUI). Both are the `mcp`
+library's own implementation; this module only chooses defaults and wires one
+extra rule for the network case: local file paths are refused rather than
+read, because "the machine running this server" stops being the caller's
+machine the moment the two are joined over a network instead of by the client
+spawning the process itself.
 """
 
 from __future__ import annotations
@@ -144,7 +153,21 @@ def _friendly(fn, client: ContentClient):
     return wrapper
 
 
-def build_server(client: ContentClient | None = None) -> MCPServer:
+def build_server(
+    client: ContentClient | None = None, *, local_paths_allowed: bool = True
+) -> MCPServer:
+    """Wire the tools/resources over *client*.
+
+    ``local_paths_allowed`` is false when the caller is started over a network
+    transport (see ``main`` / ``CONTENT_MCP_TRANSPORT``): "a path on this
+    machine" is a promise this server can only keep when the machine running
+    it is the machine that spawned it, which is what stdio guarantees and a
+    network transport does not. A local path handed to a network-transport
+    server was going to be read on whatever host the server happens to run
+    on, on behalf of whoever could reach the port — silently resolved
+    somewhere the caller did not mean. Refusing it outright is the choice
+    made publicly on r/mcp; letting it through was never on the table.
+    """
     client = client or ContentClient()
     server = MCPServer(name="content", version="0.6.8", instructions=INSTRUCTIONS)
 
@@ -171,7 +194,18 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
         MCP server runs on. A local file is read and uploaded to the engine,
         which is the only way a file here becomes usable by an engine running
         elsewhere; the path is never assumed to exist on the engine's side.
+        Over a network transport (streamable-http) local paths are refused
+        outright rather than resolved: "this machine" would be the server's
+        host, not the caller's, which is not what a path in a request means.
         """
+        if not local_paths_allowed and not service.looks_like_url(url):
+            raise ToolError(
+                f"'{url}' looks like a local path, and this server is running "
+                "over a network transport: it would be read on the server's "
+                "own host, not the caller's, which is not what a local path "
+                "in this request should mean. Give a URL instead, or run "
+                "this server over stdio to analyze local files."
+            )
         return service.analyze_source(client, url, credential=credential)
 
     @tool()
@@ -280,14 +314,27 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
 
 
 _HELP = """\
-content-mcp — the official MCP server for the Content engine (stdio).
+content-mcp — the official MCP server for the Content engine.
 
-Run it from an MCP client, not by hand: the client spawns the process and
-speaks JSON-RPC over stdin/stdout. Configuration is one environment variable:
+Run it from an MCP client, not by hand: the client either spawns the process
+(stdio, the default) or connects to it over the network (streamable-http).
+Configuration is environment variables:
 
-  CONTENT_API_URL   base URL of your Content engine (default http://localhost:8010)
+  CONTENT_API_URL       base URL of your Content engine (default http://localhost:8010)
+  CONTENT_MCP_TRANSPORT stdio (default) or streamable-http
+  CONTENT_MCP_HTTP_HOST streamable-http only — default 127.0.0.1 (loopback).
+                        Widening it to listen on every interface is a choice
+                        this server will not make for you: set it explicitly
+                        (e.g. 0.0.0.0) if that is what you want.
+  CONTENT_MCP_HTTP_PORT streamable-http only — default 8770
 
-Example client configuration:
+Local file paths (the "analyze a file on this machine" half of analyze_source)
+are only honoured over stdio, where "this machine" is unambiguous. Over
+streamable-http the server may be reachable from a different machine than the
+one a path names, so local paths are refused rather than resolved on whatever
+host happens to be running the server.
+
+Example client configuration (stdio):
 
   {
     "mcpServers": {
@@ -298,10 +345,45 @@ Example client configuration:
     }
   }
 
+Example client configuration (streamable-http, e.g. for OpenWebUI): start
+the server with CONTENT_MCP_TRANSPORT=streamable-http, then point the client
+at http://127.0.0.1:8770/mcp (or wherever CONTENT_MCP_HTTP_HOST/_PORT put it).
+
 Options:
   --help      show this help and exit
   --version   show the version and exit
 """
+
+DEFAULT_HTTP_HOST = "127.0.0.1"
+DEFAULT_HTTP_PORT = 8770
+
+
+def _transport_config() -> tuple[str, dict[str, Any]]:
+    """The transport to run, and the kwargs `MCPServer.run` wants for it.
+
+    Read from environment variables rather than argv, the same way
+    CONTENT_API_URL is: an MCP client's config gives a command and an `env`
+    block, not flags, and this keeps the two configurable the same way.
+    """
+    import os
+
+    transport = os.getenv("CONTENT_MCP_TRANSPORT", "stdio").strip() or "stdio"
+    if transport == "stdio":
+        return transport, {}
+    if transport != "streamable-http":
+        raise SystemExit(
+            f"content-mcp: unknown CONTENT_MCP_TRANSPORT {transport!r} "
+            "(expected 'stdio' or 'streamable-http')"
+        )
+    return transport, {
+        # Loopback unless the operator names something else explicitly — the
+        # library's own default agrees, this just makes the choice visible
+        # and independent of whichever default that package ships next.
+        "host": os.getenv("CONTENT_MCP_HTTP_HOST", "").strip() or DEFAULT_HTTP_HOST,
+        "port": int(
+            os.getenv("CONTENT_MCP_HTTP_PORT", "").strip() or DEFAULT_HTTP_PORT
+        ),
+    }
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -328,7 +410,8 @@ def main(argv: list[str] | None = None) -> None:
     if args:
         print(f"content-mcp: unexpected argument {args[0]!r} (try --help)")
         raise SystemExit(2)
-    build_server().run("stdio")
+    transport, kwargs = _transport_config()
+    build_server(local_paths_allowed=(transport == "stdio")).run(transport, **kwargs)
 
 
 if __name__ == "__main__":

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -29,6 +29,8 @@ INSTRUCTIONS = (
     "subtitles, transcript, summary…). Typical flow: analyze_source to see what "
     "a source is and what can be produced, then generate with the returned "
     "analysis_id, then poll get_job until it is terminal and read its artifacts. "
+    "get_job's response carries poll_after (seconds); wait that long before "
+    "calling it again rather than polling on a fixed or guessed interval. "
     "The engine names every artifact after the analyzed resource; when the "
     "server's delivery policy is on (see get_config), finished files are also "
     "copied into the server's media library and each artifact reports its "
@@ -196,7 +198,12 @@ def build_server(client: ContentClient | None = None) -> MCPServer:
 
     @tool()
     def get_job(job_id: str) -> dict[str, Any]:
-        """Get a job's status and, once terminal, its produced artifacts."""
+        """Get a job's status and, once terminal, its produced artifacts.
+
+        Carries `poll_after`: seconds to wait before calling this again — a
+        heuristic (grows with elapsed time and the kind of work the job is
+        doing), not a promise, and `null` once the job is terminal.
+        """
         return service.get_job(client, job_id)
 
     @tool()

--- a/apps/mcp/content_mcp/service.py
+++ b/apps/mcp/content_mcp/service.py
@@ -9,6 +9,7 @@ merely exposes them as MCP tools/resources.
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -268,6 +269,61 @@ def generate(
     return {"job_id": job.id, "status": job.status}
 
 
+# get_job's polling heuristic (poll_after) — promised on r/mcp to u/ChiefGrowth
+# ("polling costs calls too, give me a hint"), never shipped until now. Backoff
+# grows with how long the job has already been running: freshly started, a
+# caller can check back soon; five minutes in, checking every couple of
+# seconds is a call spent for nothing. Bounded on both ends so the suggestion
+# is never useless (0s) or a real wait the caller didn't ask for (minutes+).
+MIN_POLL_AFTER_SECONDS = 2
+MAX_POLL_AFTER_SECONDS = 60
+# A step whose operation starts with one of these is presumed slow — a
+# network fetch or a model call, minutes-scale — versus everything else the
+# planner emits (subtitle reshaping, chapter derivation/export), which runs
+# locally and is typically done in seconds. Only ever biases the *floor* of
+# the suggestion; a wrong guess here costs nothing but an extra poll.
+_SLOW_OPERATION_PREFIXES = (
+    "media.acquire_",
+    "audio.transcribe",
+    "text.summarize",
+    "text.translate",
+)
+_SLOW_FLOOR_SECONDS = 5
+
+
+def _elapsed_seconds(timestamp: str | None) -> float:
+    """Seconds since *timestamp* (an engine ISO-8601 string), or 0 if absent
+    or unparseable — an unknown age should not crash a status check, it
+    should just fall back to the shortest suggestion."""
+    if not timestamp:
+        return 0.0
+    try:
+        then = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return 0.0
+    if then.tzinfo is None:
+        then = then.replace(tzinfo=timezone.utc)
+    return max(0.0, (datetime.now(timezone.utc) - then).total_seconds())
+
+
+def _poll_after(job) -> int | None:
+    """Seconds to wait before calling get_job again — a heuristic, not a
+    promise from the engine, so a caller is free to ignore it. None once the
+    job is terminal: there is nothing left to wait for."""
+    if job.is_terminal:
+        return None
+    elapsed = _elapsed_seconds(job.data.started_at or job.data.created_at)
+    slow = any(
+        str(step.get("operation", "")).startswith(_SLOW_OPERATION_PREFIXES)
+        for step in (job.data.steps or [])
+    )
+    floor = _SLOW_FLOOR_SECONDS if slow else MIN_POLL_AFTER_SECONDS
+    # Roughly a third of the time already spent, so the interval grows with
+    # the job rather than staying flat — proportional backoff without needing
+    # a running poll count, which this stateless call does not have.
+    return max(floor, min(MAX_POLL_AFTER_SECONDS, round(elapsed / 3) or floor))
+
+
 def get_job(client: ContentClient, job_id: str) -> dict[str, Any]:
     """Job status; once terminal, the produced artifacts (metadata only), and
     when something went wrong, what went wrong.
@@ -283,6 +339,7 @@ def get_job(client: ContentClient, job_id: str) -> dict[str, Any]:
         "job_id": job.id,
         "status": job.status,
         "error": job.data.error,
+        "poll_after": _poll_after(job),
     }
     if job.status in ("failed", "partially_succeeded"):
         failures = [

--- a/apps/mcp/content_mcp/service.py
+++ b/apps/mcp/content_mcp/service.py
@@ -151,7 +151,11 @@ def _check_read_allowed(path: Path) -> Path:
     return resolved
 
 
-def _looks_like_url(value: str) -> bool:
+def looks_like_url(value: str) -> bool:
+    """Public because server.py needs it too: over a network transport, a
+    non-URL source is a local path, and the http-transport startup path
+    refuses those before they ever reach this module (see build_server's
+    ``local_paths_allowed``)."""
     return "://" in value.split("?", 1)[0][:12]
 
 
@@ -169,7 +173,7 @@ def _source_for(client: ContentClient, source: str, credential: str | None):
     description says so plainly — an agent should choose it deliberately. What
     it may read is bounded by `CONTENT_MCP_ALLOWED_READ_DIRS` (`_check_read_allowed`).
     """
-    if _looks_like_url(source):
+    if looks_like_url(source):
         return outputs.url_source(source, credential_id=credential), None
     path = Path(source).expanduser()
     if not path.is_file():

--- a/apps/mcp/tests/test_server.py
+++ b/apps/mcp/tests/test_server.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 import asyncio
 
 import httpx
-from content_mcp.server import build_server
+import pytest
+from content_mcp.server import (
+    DEFAULT_HTTP_HOST,
+    DEFAULT_HTTP_PORT,
+    _transport_config,
+    build_server,
+)
 from content_sdk import ContentClient
 
 
@@ -15,6 +21,10 @@ def _client() -> ContentClient:
         transport=httpx.MockTransport(lambda request: httpx.Response(200, json={}))
     )
     return ContentClient("http://testserver", http_client=http)
+
+
+def _call(server, name: str, arguments: dict | None = None):
+    return asyncio.run(server.call_tool(name, arguments or {}))
 
 
 def test_server_exposes_the_intention_tools():
@@ -49,3 +59,72 @@ def test_instructions_warn_that_inlined_text_is_untrusted():
     server = build_server(_client())
     assert "untrusted" in server.instructions.lower()
     assert "CONTENT_MCP_ALLOWED_READ_DIRS" in server.instructions
+
+
+# --- local paths over a network transport ---------------------------------------
+#
+# Promised on r/mcp to u/International_Emu772 alongside streamable-http itself:
+# a local path only ever meant "on the machine that spawned this process",
+# which stdio guarantees and a network transport does not. Over
+# streamable-http the server refuses local paths rather than read them on
+# whatever host happens to be running it.
+
+
+def test_local_paths_are_refused_when_not_allowed():
+    server = build_server(_client(), local_paths_allowed=False)
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "analyze_source", {"url": "/etc/passwd"})
+    message = str(excinfo.value)
+    assert "network transport" in message
+    assert "URL" in message
+
+
+def test_a_url_is_never_refused_regardless_of_local_paths_allowed():
+    server = build_server(_client(), local_paths_allowed=False)
+    # Reaches the service layer rather than being refused up front — proven
+    # by it *not* raising the local-path message (the mock client answers a
+    # bare {} for everything, so the call still fails, just differently).
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "analyze_source", {"url": "https://example.com/v"})
+    assert "network transport" not in str(excinfo.value)
+
+
+def test_local_paths_still_work_when_allowed_by_default():
+    server = build_server(_client())  # local_paths_allowed defaults to True
+    with pytest.raises(Exception) as excinfo:
+        _call(server, "analyze_source", {"url": "/no/such/file"})
+    # Falls through to the ordinary "not a file" rejection, not the
+    # transport refusal — proves the default (stdio) path is unchanged.
+    assert "neither a URL nor a file" in str(excinfo.value)
+
+
+# --- transport selection (CONTENT_MCP_TRANSPORT and friends) --------------------
+
+
+def test_default_transport_is_stdio(monkeypatch):
+    monkeypatch.delenv("CONTENT_MCP_TRANSPORT", raising=False)
+    assert _transport_config() == ("stdio", {})
+
+
+def test_streamable_http_defaults_to_loopback(monkeypatch):
+    monkeypatch.setenv("CONTENT_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.delenv("CONTENT_MCP_HTTP_HOST", raising=False)
+    monkeypatch.delenv("CONTENT_MCP_HTTP_PORT", raising=False)
+    transport, kwargs = _transport_config()
+    assert transport == "streamable-http"
+    assert kwargs["host"] == DEFAULT_HTTP_HOST == "127.0.0.1"
+    assert kwargs["port"] == DEFAULT_HTTP_PORT
+
+
+def test_streamable_http_host_and_port_are_configurable(monkeypatch):
+    monkeypatch.setenv("CONTENT_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("CONTENT_MCP_HTTP_HOST", "0.0.0.0")
+    monkeypatch.setenv("CONTENT_MCP_HTTP_PORT", "9999")
+    _transport, kwargs = _transport_config()
+    assert kwargs == {"host": "0.0.0.0", "port": 9999}
+
+
+def test_an_unknown_transport_is_refused(monkeypatch):
+    monkeypatch.setenv("CONTENT_MCP_TRANSPORT", "carrier-pigeon")
+    with pytest.raises(SystemExit, match="carrier-pigeon"):
+        _transport_config()

--- a/apps/mcp/tests/test_service.py
+++ b/apps/mcp/tests/test_service.py
@@ -324,6 +324,103 @@ def test_a_succeeded_job_carries_no_failure_noise():
     assert result["error"] == ""
 
 
+# --- poll_after: a heuristic hint for how long to wait before polling again ---
+#
+# Promised on r/mcp to u/ChiefGrowth ("polling costs calls too, give me a
+# hint") and shipped here: get_job now returns poll_after (seconds), grown
+# from how long the job has been running and biased upward for steps that are
+# typically slow (a network fetch, a model call).
+
+
+def _job_response(status: str, *, started_at: str | None, steps=None):
+    return {
+        "job_id": "job_x",
+        "status": status,
+        "error": "",
+        "created_at": started_at or "2026-01-01T00:00:00+00:00",
+        "started_at": started_at,
+        "steps": steps or [],
+    }
+
+
+def test_poll_after_is_null_once_terminal():
+    def handler(request):
+        if request.url.path.endswith("/artifacts"):
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json=_job_response("succeeded", started_at=None))
+
+    result = service.get_job(_api(handler), "job_x")
+    assert result["poll_after"] is None
+
+
+def test_poll_after_is_present_for_a_running_job():
+    def handler(request):
+        return httpx.Response(200, json=_job_response("running", started_at=None))
+
+    result = service.get_job(_api(handler), "job_x")
+    assert isinstance(result["poll_after"], int)
+    assert result["poll_after"] >= service.MIN_POLL_AFTER_SECONDS
+
+
+def test_poll_after_grows_with_elapsed_time():
+    from datetime import datetime, timedelta, timezone
+
+    def handler(seconds_ago: int):
+        started = (
+            datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)
+        ).isoformat()
+
+        def _handler(request):
+            return httpx.Response(
+                200, json=_job_response("running", started_at=started)
+            )
+
+        return _handler
+
+    fresh = service.get_job(_api(handler(1)), "job_x")["poll_after"]
+    long_running = service.get_job(_api(handler(300)), "job_x")["poll_after"]
+    assert fresh < long_running
+    assert long_running <= service.MAX_POLL_AFTER_SECONDS
+
+
+def test_poll_after_has_a_higher_floor_for_a_slow_operation():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json=_job_response(
+                "running",
+                started_at=None,
+                steps=[
+                    {
+                        "step_id": "s",
+                        "operation": "audio.transcribe",
+                        "status": "running",
+                    }
+                ],
+            ),
+        )
+
+    result = service.get_job(_api(handler), "job_x")
+    assert result["poll_after"] >= service._SLOW_FLOOR_SECONDS
+
+
+def test_poll_after_tolerates_a_missing_or_unparseable_timestamp():
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "job_id": "job_x",
+                "status": "running",
+                "error": "",
+                "created_at": "not-a-timestamp",
+                "steps": [],
+            },
+        )
+
+    result = service.get_job(_api(handler), "job_x")
+    assert result["poll_after"] == service.MIN_POLL_AFTER_SECONDS
+
+
 def test_retry_job_reruns_the_request_and_names_its_ancestor():
     """`cancel_job` had no counterpart: an agent that watched a job fail could
     report the failure and nothing else. The answer carries `retry_of` so the


### PR DESCRIPTION
The two public commitments from the r/mcp thread, delivered:

- **`poll_after`** on `get_job` (promised to u/ChiefGrowth): async jobs now tell the client when to come back instead of leaving it polling blind.
- **streamable-http transport** (promised to u/International_Emu772), with both publicly stated conditions honored: **loopback by default**, and **local paths refused** rather than resolved elsewhere.

46→58 tests green locally.