### PR TITLE
Version 0.7.0

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.6.8"
+    org.opencontainers.image.version="0.7.0"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.6.8"
+__version__ = "0.7.0"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.6.8"
+version = "0.7.0"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.6.8"
+version = "0.7.0"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.6.8"]
+dependencies = ["content-sdk==0.7.0"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -169,7 +169,7 @@ def build_server(
     made publicly on r/mcp; letting it through was never on the table.
     """
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.6.8", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.7.0", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.6.8"
+version = "0.7.0"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.6.8", "mcp>=1.2"]
+dependencies = ["content-sdk==0.7.0", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.8"
+__version__ = "0.7.0"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.8"
+__version__ = "0.7.0"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.6.8"
+version = "0.7.0"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.6.8"
+__version__ = "0.7.0"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.7.0.md
+++ b/docs/releases/v0.7.0.md
@@ -1,0 +1,82 @@
+A capability is now judged by what a source can *yield*, not only by what it
+carries — which turns "PDF export isn't available for this video" from a false
+answer into a working one. Plus a second MCP transport, an honest polling
+hint, and three security-audit findings closed.
+
+## A summary PDF from any talking video
+
+The engine could always do it — analyze, transcribe, summarize, render — but
+only if you spelled the chain out with `from_outputs`. Asked plainly,
+`[{"type": "pdf"}]` on a video was refused at feasibility, and
+`POST /capabilities` reported `pdf.render: unavailable (missing_material:
+text)` three lines under `summary.generate: derivable`. Every agent fronting
+the engine faithfully repeated the false half.
+
+Documents now get the judgement transcripts and summaries always had
+([ADR 0028](https://github.com/LatentNoise/content/blob/main/docs/architecture-decisions/0028-documents-are-derivable-through-text.md)):
+
+- **`pdf.render` and `markdown.export` are `derivable` on a source whose text
+  can be produced**, with `selected_variant` naming the path
+  (`pdf.render.via_summary` — subtitles when present, speech-to-text when
+  installed). `text.extract` stays honestly `unavailable` on a video:
+  extracting is not deriving.
+- **A plain `{"type": "pdf"}` plans the derivation itself.** It renders a text
+  output already in your request when there is one (a summary first, then a
+  transcript, then a translation), otherwise it inserts the default summary
+  chain. `markdown` does the same, minus the render step — its canonical form
+  already is Markdown — and asking for both costs **one** summarization,
+  shared by step signature.
+- **The explicit form always wins.** `{"type": "pdf", "from_outputs": ["t"]}`
+  still means exactly the transcript, and stays the way to say precisely
+  which text you want rendered. The default is the summary on purpose: a
+  40-page verbatim transcript is rarely what "a PDF of this video" means.
+- **The artifact says what it contains.** A derived document is named
+  `Talk - summary.pdf` — the same name the explicit composition produces —
+  never the bare `Talk.pdf`, which would claim the file *is* the talk.
+
+When a document is still impossible, the refusal now names the missing piece
+in your terms — *"the source carries no text, subtitles or audio to build it
+from"*, a missing runner (`text.summarize`, `audio.transcribe`), or the
+blocking policy — instead of the bare *"'pdf' cannot be produced from source
+'main'."*
+
+## MCP: a second transport, for clients that cannot spawn a process
+
+`CONTENT_MCP_TRANSPORT=streamable-http` starts the same server over HTTP —
+for Open WebUI and every other client that cannot spawn a subprocess. The two
+conditions stated when this was promised publicly hold: **loopback by
+default** (`CONTENT_MCP_HTTP_HOST=127.0.0.1`, port 8770), and **local paths
+refused** over the network transport rather than silently resolved on
+whatever host the server happens to run on. stdio remains the default and the
+recommended transport; the reasons in the
+[MCP guide](https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md)
+have not moved.
+
+## MCP: `get_job` tells you when to ask again
+
+Job answers now carry `poll_after` — the engine's own estimate of when the
+next poll is worth making. An agent that respects it stops burning its context
+window on `running… running… running…`.
+
+## MCP: three audit findings closed
+
+From the 2026-08-23 security audit of the MCP server:
+
+- **`analyze_source` gets a read boundary.** `CONTENT_MCP_ALLOWED_READ_DIRS`
+  confines local-file reads the way `download_artifact` was always confined —
+  and every local read is refused by default until the operator opens a
+  directory. Same shape as the engine's own `CONTENT_ALLOWED_INPUT_ROOTS`.
+- **A symlink as the final path component no longer slips past
+  `download_artifact`'s boundary check** — the path is fully resolved before
+  the check, matching what the docstring already claimed.
+- **Artifact content read back through MCP is marked untrusted**, so an agent
+  has a fighting chance against instructions embedded in a downloaded
+  subtitle file.
+
+## Operators: a release is not verified until the deployment answers
+
+`make verify-deployment ENGINE=http://…:8010 VERSION=x.y.z` asks the running
+engine the questions a test suite cannot: the served version, the real tool
+versions behind `/health`, an analysis, a capability resolution, and one
+end-to-end job whose artifact reads back byte-identical — submitted with
+`delivery: none`, so verification leaves nothing in your library.

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.6.8"
+__version__ = "0.7.0"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.6.8"
+version = "0.7.0"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.6.8",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
The release bump and notes for v0.7.0, per docs/operations/releasing.md step 2: every version declaration moves to 0.7.0 (`make version` proves 17 agree), and [docs/releases/v0.7.0.md](https://github.com/LatentNoise/content/blob/release/v0.7.0/docs/releases/v0.7.0.md) becomes the draft's body verbatim.

Ships: derivable documents (ADR 0028, #77), the streamable-http MCP transport, `poll_after` in `get_job`, and the three security-audit closures.