### PR TITLE
The capability feed says what a derivation passes through

### DIFF
--- a/apps/backend/content/capabilities/resolver.py
+++ b/apps/backend/content/capabilities/resolver.py
@@ -193,6 +193,27 @@ def select_variant(
     return classify_capability(cap, facts, registry, providers, policy)[1]
 
 
+def _derivation_for(
+    variant: RecipeVariant, registry: TransformationRegistry
+) -> list[str]:
+    """The material chain the variant walks, source first, artifact last —
+    read from the registry's own ``output_kinds`` declarations (R1: one
+    declaration), so ``pdf.render.via_summary`` answers
+    ["subtitles", "transcript", "summary", "pdf"] without any per-capability
+    hand-writing. Consecutive duplicates collapse (an acquisition *of* the
+    required material adds nothing to the story)."""
+    chain = [_material_name(kind) for kind in variant.requires_materials]
+    for op in variant.operations:
+        definition = registry.definition(op)
+        if definition is None:
+            continue
+        for kind in definition.output_kinds:
+            name = _material_name(kind)
+            if not chain or chain[-1] != name:
+                chain.append(name)
+    return chain
+
+
 def _resolve_one(
     cap: CapabilityDef,
     facts: SourceFacts,
@@ -216,6 +237,7 @@ def _resolve_one(
         status=status,
         selected_variant=variant.id if variant is not None else None,
         derived_from=derived_from,
+        derivation=_derivation_for(variant, registry) if variant is not None else [],
         reason=reason,
     )
 

--- a/apps/backend/content/domain/capability.py
+++ b/apps/backend/content/domain/capability.py
@@ -42,5 +42,13 @@ class ResolvedCapability(BaseModel):
     # For derivable capabilities, the source material(s) it is built from
     # (e.g. ["subtitles"] for summary.from_subtitles).
     derived_from: list[str] = Field(default_factory=list)
+    # The whole path the selected variant takes, source material first,
+    # artifact last — e.g. ["subtitles", "transcript", "summary", "pdf"] for
+    # pdf.render.via_summary (ADR 0028). `derived_from` names where a
+    # derivation starts; this names what it passes through, which is the
+    # difference between "a PDF from subtitles" and the truth — a PDF *of the
+    # summary*. Computed from the transformation registry's own declarations,
+    # never hand-written per capability.
+    derivation: list[str] = Field(default_factory=list)
     # Structured reason when status is not available/derivable.
     reason: CapabilityReason | None = None

--- a/apps/backend/tests/test_derived_documents.py
+++ b/apps/backend/tests/test_derived_documents.py
@@ -10,6 +10,8 @@ source where no derivation exists is still refused — with the missing piece
 named.
 """
 
+import pathlib
+
 import pytest
 
 from content.capabilities.catalog import capability
@@ -134,6 +136,60 @@ def test_text_extract_still_means_text_the_source_itself_carries():
     assert caps["text.extract"].status == "unavailable"
     assert caps["text.extract"].reason.code == "missing_material"
     assert caps["text.extract"].reason.missing_materials == ["text"]
+
+
+def test_the_derivation_chain_says_what_the_document_will_contain():
+    """The public answer for "derived how?": the whole material chain, read
+    from the registry's own declarations — the difference between "a PDF from
+    subtitles" and the truth, a PDF *of the summary* (ADR 0028)."""
+    caps = _resolved(_video_with_subs(), _providers())
+    assert caps["pdf.render"].derivation == [
+        "subtitles",
+        "transcript",
+        "summary",
+        "pdf",
+    ]
+    assert caps["markdown.export"].derivation == [
+        "subtitles",
+        "transcript",
+        "summary",
+    ]
+    assert caps["summary.generate"].derivation == [
+        "subtitles",
+        "transcript",
+        "summary",
+    ]
+    assert caps["transcript.generate"].derivation == ["subtitles", "transcript"]
+    # A direct capability's chain collapses to its own material: nothing to say.
+    assert caps["subtitles.download"].derivation == ["subtitles"]
+    # And a blocked capability has no selected variant, so no chain to claim.
+    assert caps["text.extract"].derivation == []
+
+
+def test_the_derivation_chain_reaches_the_public_capability_feed():
+    """Clients read /capabilities, not the resolver — the chain must survive
+    the trip so a UI can render "subtitles → transcript → summary → pdf"."""
+    import tempfile
+
+    from content.config import ContentSettings
+
+    with tempfile.TemporaryDirectory() as tmp:
+        settings = ContentSettings(
+            data_dir=pathlib.Path(tmp), db_path=pathlib.Path(tmp) / "c.db"
+        )
+        with _api(settings, _providers()) as client:
+            response = client.post(
+                "/api/v1/capabilities",
+                json={"sources": [{"id": "d", "type": "url", "uri": "https://x/talk"}]},
+            )
+    assert response.status_code == 200, response.text
+    caps = {c["id"]: c for c in response.json()["sources"][0]["capabilities"]}
+    assert caps["pdf.render"]["derivation"] == [
+        "subtitles",
+        "transcript",
+        "summary",
+        "pdf",
+    ]
 
 
 def test_planner_builds_exactly_the_variant_the_resolver_selected():

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -508,11 +508,18 @@ with tab_caps:
             )
             for c in res["capabilities"]:
                 icon, color = capability_display(c["status"])
-                derived = (
-                    f" ← {', '.join(c['derived_from'])}"
-                    if c.get("derived_from")
-                    else ""
-                )
+                # The full chain when the engine reports one (ADR 0028):
+                # "subtitles → transcript → summary → pdf" says what a
+                # derivable actually contains — a PDF *of the summary* —
+                # where the bare "← subtitles" left that unsaid. Older
+                # engines without `derivation` keep the old display.
+                chain = c.get("derivation") or []
+                if c["status"] == "derivable" and len(chain) > 1:
+                    derived = "  ·  " + " → ".join(chain)
+                elif c.get("derived_from"):
+                    derived = f" ← {', '.join(c['derived_from'])}"
+                else:
+                    derived = ""
                 reason = _reason_str(c.get("reason"))
                 st.markdown(
                     f"<div class='step'>{icon} <b>{c['id']}</b> "

--- a/docs/architecture/analysis-to-capabilities.md
+++ b/docs/architecture/analysis-to-capabilities.md
@@ -129,6 +129,7 @@ implementation allowed by the policy. It returns a
   "status": "derivable",          // available | derivable | unavailable | restricted | unknown
   "selected_variant": "summary.from_subtitles",
   "derived_from": ["subtitles"],
+  "derivation": ["subtitles", "transcript", "summary"],
   "reason": null                  // structured when unavailable (see below)
 }
 ```
@@ -138,6 +139,14 @@ identity (`resource_type`, `title`) and **`suggested_filename`** — the base
 name the naming engine (ADR 0017) would give this source's artifacts, so a UI
 prefills its filename field with an editable proposal instead of
 re-implementing the display profile client-side.
+
+`derivation` is the whole material chain the selected variant walks, source
+first, artifact last — `["subtitles", "transcript", "summary", "pdf"]` for
+`pdf.render.via_summary` (ADR 0028). `derived_from` says where a derivation
+starts; `derivation` says what it passes through, which is how a client can
+show that a derivable PDF on a video is a PDF *of the summary* rather than
+"a PDF from subtitles". It is computed from the transformation registry's
+`output_kinds` declarations, never hand-written per capability.
 
 ### Statuses and tri-state materials
 

--- a/docs/domain.md
+++ b/docs/domain.md
@@ -55,7 +55,7 @@ This document defines the concepts, their invariants and the state machines. The
 Level 3 is exposed by `POST /capabilities` (not in the analysis), as a list of `ResolvedCapability` objects from the **public catalog** (`video.download`, `summary.generate`, …), with the statuses:
 
 - `available` — a direct download (the material is the output);
-- `derivable` — produced by transformation (`derived_from: [...]`);
+- `derivable` — produced by transformation (`derived_from: [...]`, full chain in `derivation: [...]`);
 - `unavailable` — impossible, with a **structured reason** (`missing_material` = incompatible source; `implementation_unavailable` = missing runner; `policy_restricted`);
 - `restricted` — feasible but blocked by the effective policy;
 - `unknown` — no proven impossibility, insufficient facts; never presented as `available`, an attempt is allowed, the uncertainty is traceable (R8).


### PR DESCRIPTION
Follow-up to #77, from reading the Admin UI against a real video: `pdf.render derivable ← subtitles` is true and still misleading — it reads as "a PDF from subtitles" when the selected variant goes subtitles → transcript → **summary** → pdf. The path existed only inside the variant id, which no client should parse.

`ResolvedCapability` gains **`derivation`**: the whole material chain of the selected variant, source first, artifact last — `["subtitles", "transcript", "summary", "pdf"]` — computed from the transformation registry's own `output_kinds` declarations (R1: one declaration, nothing hand-written per capability, future variants get their chain for free). `derived_from` is untouched; the field is additive.

Content Admin renders it: a derivable row now reads `pdf.render derivable · subtitles → transcript → summary → pdf`, falling back to the old display against an older engine. Docs updated (analysis-to-capabilities, domain.md). `make validate` green (824 backend, 2 new tests: resolver chains + the field surviving to `POST /capabilities`).