### PR TITLE
Version 0.7.1

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -30,7 +30,7 @@ LABEL org.opencontainers.image.base.name="docker.io/jauderho/yt-dlp:${YTDLP_BASE
     org.opencontainers.image.source="https://github.com/LatentNoise/content" \
     org.opencontainers.image.authors="Yann Orieult" \
     org.opencontainers.image.url="https://github.com/LatentNoise/content" \
-    org.opencontainers.image.version="0.7.0"
+    org.opencontainers.image.version="0.7.1"
 
 # ttf-dejavu: PDF output for non-Latin scripts. Without a Unicode font the
 # renderer falls back to Helvetica, which draws Latin-1 only — a Japanese or

--- a/apps/backend/content/__init__.py
+++ b/apps/backend/content/__init__.py
@@ -1,3 +1,3 @@
 """Content — declarative resource-to-artifact generation engine."""
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-backend"
-version = "0.7.0"
+version = "0.7.1"
 description = "Content — declarative resource-to-artifact generation engine"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/browser-extension-chromium/manifest.json
+++ b/apps/browser-extension-chromium/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "HomeTube for Content",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Send the page you are watching to your Content engine, in one click.",
   "homepage_url": "https://github.com/LatentNoise/content",
   "minimum_chrome_version": "102",

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "Command-line client for the Content engine (talks to /api/v1)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -24,7 +24,7 @@ classifiers = [
 # Pinned to the exact SDK release, not a floor: the monorepo ships one version
 # for everything (`make version`), and a CLI resolving to a different SDK than
 # the one it was tested against is precisely the drift that guarantees buys.
-dependencies = ["content-sdk==0.7.0"]
+dependencies = ["content-sdk==0.7.1"]
 
 [project.scripts]
 content = "content_cli.cli:main"

--- a/apps/mcp/content_mcp/server.py
+++ b/apps/mcp/content_mcp/server.py
@@ -169,7 +169,7 @@ def build_server(
     made publicly on r/mcp; letting it through was never on the table.
     """
     client = client or ContentClient()
-    server = MCPServer(name="content", version="0.7.0", instructions=INSTRUCTIONS)
+    server = MCPServer(name="content", version="0.7.1", instructions=INSTRUCTIONS)
 
     def tool():
         """`server.tool()`, with SDK errors translated on the way out."""

--- a/apps/mcp/pyproject.toml
+++ b/apps/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Official MCP server for the Content engine (agentic facade over the SDK)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -25,7 +25,7 @@ classifiers = [
 # for everything (`make version`), and an MCP server resolving to a different
 # SDK than the one it was tested against is precisely the drift that pin buys
 # away. The `mcp` framework is an external dependency and keeps a floor.
-dependencies = ["content-sdk==0.7.0", "mcp>=1.2"]
+dependencies = ["content-sdk==0.7.1", "mcp>=1.2"]
 
 [project.scripts]
 content-mcp = "content_mcp.server:main"

--- a/apps/web-admin/app.py
+++ b/apps/web-admin/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 TERMINAL = {"succeeded", "partially_succeeded", "failed", "cancelled"}
 CATEGORY_ORDER = [

--- a/apps/web-hometube/app.py
+++ b/apps/web-hometube/app.py
@@ -26,7 +26,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 # HomeTube logo: gradient rounded square with a white play triangle. Embedded
 # inline (base64 data URI) so no binary asset is needed and the mark stays

--- a/apps/web-hometube/pyproject.toml
+++ b/apps/web-hometube/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-frontend"
-version = "0.7.0"
+version = "0.7.1"
 description = "Content — Streamlit front-end (pure API client of the back-end)"
 license = "AGPL-3.0-or-later"
 authors = [{ name = "Yann Orieult" }]

--- a/apps/web-studio/app.py
+++ b/apps/web-studio/app.py
@@ -25,7 +25,7 @@ PUBLIC_API_URL = os.getenv("CONTENT_PUBLIC_API_URL", API_URL).rstrip("/")
 # This app's own release, in lockstep with the whole monorepo (`make version`
 # guards every declaration). Passed to the notification bar so the launch check
 # can compare it against the backend's version and warn on a torn deployment.
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 # Fallback ordering only. The real list comes from the server's resolved
 # capabilities, each of which carries its own `output_type` — see

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,31 @@
+One field, added because a true answer was still a misleading one.
+
+## A derivable capability names the path it takes
+
+v0.7.0 made `pdf.render` and `markdown.export` derivable on a video — and
+reported them as `derivable ← subtitles`, which reads as "a PDF from the
+subtitles". The real path is subtitles → transcript → **summary** → pdf: the
+default deliberately produces a summary document, not a transcript dump
+(ADR 0028), and nothing in the feed said so.
+
+Each resolved capability now carries **`derivation`** — the whole material
+chain of its selected variant, source first, artifact last:
+
+```jsonc
+{
+  "id": "pdf.render",
+  "status": "derivable",
+  "selected_variant": "pdf.render.via_summary",
+  "derived_from": ["subtitles"],
+  "derivation": ["subtitles", "transcript", "summary", "pdf"]
+}
+```
+
+It is computed from the transformation registry's own declarations — one
+source of truth, so any future variant answers its chain for free — and the
+field is additive: `derived_from` is unchanged and older clients simply
+ignore it.
+
+Content Admin renders it: a derivable row now reads
+`pdf.render derivable · subtitles → transcript → summary → pdf`, and falls
+back to the previous display against an older engine.

--- a/packages/python-sdk/content_sdk/__init__.py
+++ b/packages/python-sdk/content_sdk/__init__.py
@@ -42,7 +42,7 @@ from .models import (
 )
 from .resources import Analysis, Job
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 __all__ = [
     "ORIGINAL",

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "content-sdk"
-version = "0.7.0"
+version = "0.7.1"
 description = "Official Python SDK for the Content engine (the one API client: sync + async)."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.LatentNoise/content",
   "title": "Content",
   "description": "Turn URLs, files and text into media, transcripts, summaries, translations and PDF.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "websiteUrl": "https://github.com/LatentNoise/content/blob/main/apps/mcp/README.md",
   "repository": {
     "url": "https://github.com/LatentNoise/content",
@@ -14,7 +14,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "content-mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump + notes for v0.7.1, per docs/operations/releasing.md: 17 declarations agree; [docs/releases/v0.7.1.md](https://github.com/LatentNoise/content/blob/release/v0.7.1/docs/releases/v0.7.1.md) is the draft body. Ships #79 — the `derivation` chain on resolved capabilities, and its rendering in Content Admin.