### PR TITLE
yt-dlp base 2026.08.19: take the republished image

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -15,7 +15,7 @@
 # docs/operations/ytdlp-base-image.md. A scheduled workflow files an issue when
 # a newer upstream image appears; it never edits this file.
 ARG YTDLP_BASE_VERSION=2026.08.19
-ARG YTDLP_BASE_DIGEST=sha256:11c9231bd209580b25e81daad39b3bbbd06c31443d0f9dab2c196e90c6e76156
+ARG YTDLP_BASE_DIGEST=sha256:e8bf3e410176ed66ae7719b279147d502bf521200431b7bf299aa19c29fcbe27
 FROM jauderho/yt-dlp:${YTDLP_BASE_VERSION}@${YTDLP_BASE_DIGEST}
 
 # Re-declared: an ARG consumed by FROM is out of scope in the build stage.


### PR DESCRIPTION
Closes #71. Same yt-dlp, patched base layers — the deliberate digest bump the notification asked for.

One correction to the issue's numbers: upstream rebuilt **again** after it was filed, so the pin takes what `2026.08.19` resolves to **today**, read from the registry directly: `sha256:e8bf3e41…` (the issue quoted `sha256:a2e65ff3…`).

The whole gate from the issue ran locally before the commit:

1. pin updated in `apps/backend/Dockerfile`
2. `docker compose build content` — built on the new base
3. `make validate` — green (824 backend / 9 / 67 / 43 / 59)
4. `make validate-release` — 7 + 8 passed
5. coverage line reads **`[x] yt-dlp media source`** — the slice ran, not skipped
6. `docker compose run --rm --entrypoint yt-dlp content --version` → **2026.08.19**